### PR TITLE
feat(comparison): add GPS and other ffmpeg metadata

### DIFF
--- a/QtProject/app/common.pri
+++ b/QtProject/app/common.pri
@@ -5,7 +5,7 @@ QT += core gui widgets sql concurrent
 
 QMAKE_TARGET_PRODUCT = \"\\\"$$TARGET\\\"\"
 QMAKE_TARGET_DESCRIPTION = \"\\\"$$TARGET\\\"\"
-QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2020-2024 Théophane Mayaud, 2018-2019 Kristian Koskim\\344ki"
+QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2020-2025 Théophane Mayaud, 2018-2019 Kristian Koskim\\344ki"
 
 DEFINES += APP_NAME=\"\\\"$$TARGET\\\"\"
 DEFINES += APP_COPYRIGHT=\"\\\"$$QMAKE_TARGET_COPYRIGHT\\\"\"

--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -73,6 +73,12 @@ Comparison::Comparison(const QVector<Video *> &videosParam, Prefs &prefsParam) :
     QShortcut* upShortcut = new QShortcut(QKeySequence(QKeySequence::MoveToPreviousLine), ui->tabManual);
     connect(upShortcut, SIGNAL(activated()), this, SLOT(on_prevVideo_clicked()));
 
+    // we only show gps info if at least one of the files has it
+    ui->labelLeftGps->setVisible(false);
+    ui->leftGpsCoordinates->setVisible(false);
+    ui->labelRightGps->setVisible(false);
+    ui->rightGpsCoordinates->setVisible(false);
+
     on_nextVideo_clicked();
 }
 
@@ -363,6 +369,13 @@ void Comparison::showVideo(const QString &side)
         this->ui->leftGpsCoordinates->setVisible(true);
         this->ui->labelRightGps->setVisible(true);
         this->ui->rightGpsCoordinates->setVisible(true);
+    }
+
+    auto *metadata = this->findChild<QTextEdit *>(QStringLiteral("textEdit_%1Metadata").arg(side));
+    if (metadata){
+        metadata->clear();
+        for (auto it = _videos[thisVideo]->meta.fileMetadata.cbegin(); it != _videos[thisVideo]->meta.fileMetadata.cend(); ++it)
+            metadata->append(QStringLiteral("%1: %2").arg(it.key(), it.value()));
     }
 }
 

--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -353,6 +353,23 @@ void Comparison::showVideo(const QString &side)
 
     auto *Audio = this->findChild<QLabel *>(side + QStringLiteral("Audio"));
     Audio->setText(_videos[thisVideo]->audio);
+
+    // Add these lines for GPS Coordinates
+    auto *GpsCoordinatesLabel = this->findChild<QLabel *>(side + QStringLiteral("GpsCoordinates"));
+    if (GpsCoordinatesLabel) { // Check if the label exists
+        if (!_videos[thisVideo]->meta.gpsCoordinates.isEmpty()) {
+            GpsCoordinatesLabel->setText(_videos[thisVideo]->meta.gpsCoordinates);
+            GpsCoordinatesLabel->setVisible(true);
+            // Also ensure the static label "GPS:" is visible
+            QLabel* staticGpsLabel = this->findChild<QLabel *>("label" + side.left(1).toUpper() + side.mid(1) + "Gps");
+            if(staticGpsLabel) staticGpsLabel->setVisible(true);
+        } else {
+            GpsCoordinatesLabel->setText(QStringLiteral("N/A")); // Or clear it: GpsCoordinatesLabel->clear();
+            GpsCoordinatesLabel->setVisible(false); // Optionally hide if no data
+            QLabel* staticGpsLabel = this->findChild<QLabel *>("label" + side.left(1).toUpper() + side.mid(1) + "Gps");
+            if(staticGpsLabel) staticGpsLabel->setVisible(false); // Optionally hide "GPS:" label
+        }
+    }
 }
 
 QString Comparison::readableDuration(const int64_t &milliseconds) const
@@ -501,6 +518,20 @@ void Comparison::highlightBetterProperties() const
         ui->leftAudio->setStyleSheet(TEXT_STYLE_ORANGE);
         ui->rightAudio->setStyleSheet(TEXT_STYLE_ORANGE);
     }
+
+    // Add these lines for GPS Coordinates styling
+    ui->leftGpsCoordinates->setStyleSheet(QStringLiteral(""));
+    ui->rightGpsCoordinates->setStyleSheet(QStringLiteral(""));
+    if (!_videos[_leftVideo]->meta.gpsCoordinates.isEmpty() &&
+        _videos[_leftVideo]->meta.gpsCoordinates == _videos[_rightVideo]->meta.gpsCoordinates) {
+        ui->leftGpsCoordinates->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightGpsCoordinates->setStyleSheet(TEXT_STYLE_ORANGE);
+    } else if (_videos[_leftVideo]->meta.gpsCoordinates.isEmpty() && _videos[_rightVideo]->meta.gpsCoordinates.isEmpty()) {
+        // Both empty, could also style as orange or leave default
+        ui->leftGpsCoordinates->setStyleSheet(QStringLiteral("")); // Default or some indication
+        ui->rightGpsCoordinates->setStyleSheet(QStringLiteral(""));
+    }
+    // No specific "better" styling for different GPS coordinates
 }
 
 void Comparison::updateUI()

--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -12,6 +12,7 @@ enum FILENAME_CONTAINED_WITHIN_ANOTHER : int
     RIGHT_CONTAINS_LEFT
 };
 
+const QString TEXT_STYLE_GREEN = QStringLiteral("QLabel { color : green; }");
 const QString TEXT_STYLE_ORANGE = QStringLiteral("QLabel { color : peru; }");
 
 const int64_t FILE_SIZE_BYTES_DIFF_STILL_EQUALS = 100*1024;
@@ -354,21 +355,14 @@ void Comparison::showVideo(const QString &side)
     auto *Audio = this->findChild<QLabel *>(side + QStringLiteral("Audio"));
     Audio->setText(_videos[thisVideo]->audio);
 
-    // Add these lines for GPS Coordinates
     auto *GpsCoordinatesLabel = this->findChild<QLabel *>(side + QStringLiteral("GpsCoordinates"));
-    if (GpsCoordinatesLabel) { // Check if the label exists
-        if (!_videos[thisVideo]->meta.gpsCoordinates.isEmpty()) {
-            GpsCoordinatesLabel->setText(_videos[thisVideo]->meta.gpsCoordinates);
-            GpsCoordinatesLabel->setVisible(true);
-            // Also ensure the static label "GPS:" is visible
-            QLabel* staticGpsLabel = this->findChild<QLabel *>("label" + side.left(1).toUpper() + side.mid(1) + "Gps");
-            if(staticGpsLabel) staticGpsLabel->setVisible(true);
-        } else {
-            GpsCoordinatesLabel->setText(QStringLiteral("N/A")); // Or clear it: GpsCoordinatesLabel->clear();
-            GpsCoordinatesLabel->setVisible(false); // Optionally hide if no data
-            QLabel* staticGpsLabel = this->findChild<QLabel *>("label" + side.left(1).toUpper() + side.mid(1) + "Gps");
-            if(staticGpsLabel) staticGpsLabel->setVisible(false); // Optionally hide "GPS:" label
-        }
+    if (!_videos[thisVideo]->meta.gpsCoordinates.isEmpty()) {
+        GpsCoordinatesLabel->setText(_videos[thisVideo]->meta.gpsCoordinates);
+        // as soon as one has gps, show the data and labels for both
+        this->ui->labelLeftGps->setVisible(true);
+        this->ui->leftGpsCoordinates->setVisible(true);
+        this->ui->labelRightGps->setVisible(true);
+        this->ui->rightGpsCoordinates->setVisible(true);
     }
 }
 
@@ -416,75 +410,75 @@ void Comparison::highlightBetterProperties() const
     ui->rightFileSize->setStyleSheet(QStringLiteral(""));       //both filesizes within 100 kB
     if(qAbs(_videos[_leftVideo]->size - _videos[_rightVideo]->size) <= FILE_SIZE_BYTES_DIFF_STILL_EQUALS)
     {
-        ui->leftFileSize->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightFileSize->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftFileSize->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightFileSize->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->size > _videos[_rightVideo]->size)
-        ui->leftFileSize->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftFileSize->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->size < _videos[_rightVideo]->size)
-        ui->rightFileSize->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightFileSize->setStyleSheet(TEXT_STYLE_GREEN);
 
     ui->leftDuration->setStyleSheet(QStringLiteral(""));
     ui->rightDuration->setStyleSheet(QStringLiteral(""));       //both runtimes within 1 second
     if(qAbs(_videos[_leftVideo]->duration - _videos[_rightVideo]->duration) <= VIDEO_DURATION_STILL_EQUALS_MS)
     {
-        ui->leftDuration->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightDuration->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftDuration->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightDuration->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->duration > _videos[_rightVideo]->duration)
-        ui->leftDuration->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftDuration->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->duration < _videos[_rightVideo]->duration)
-        ui->rightDuration->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightDuration->setStyleSheet(TEXT_STYLE_GREEN);
 
     ui->leftBitRate->setStyleSheet(QStringLiteral(""));
     ui->rightBitRate->setStyleSheet(QStringLiteral(""));
     if(qAbs(_videos[_leftVideo]->bitrate - _videos[_rightVideo]->bitrate)<=BITRATE_DIFF_STILL_EQUAL_kbs) //leave some margin due to decoding error
     {
-        ui->leftBitRate->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightBitRate->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftBitRate->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightBitRate->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->bitrate > _videos[_rightVideo]->bitrate)
-        ui->leftBitRate->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftBitRate->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->bitrate < _videos[_rightVideo]->bitrate)
-        ui->rightBitRate->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightBitRate->setStyleSheet(TEXT_STYLE_GREEN);
 
     ui->leftFrameRate->setStyleSheet(QStringLiteral(""));
     ui->rightFrameRate->setStyleSheet(QStringLiteral(""));      //both framerates within 0.1 fps
     if(qAbs(_videos[_leftVideo]->framerate - _videos[_rightVideo]->framerate) <= 0.1)
     {
-        ui->leftFrameRate->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightFrameRate->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftFrameRate->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightFrameRate->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->framerate > _videos[_rightVideo]->framerate)
-        ui->leftFrameRate->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftFrameRate->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->framerate < _videos[_rightVideo]->framerate)
-        ui->rightFrameRate->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightFrameRate->setStyleSheet(TEXT_STYLE_GREEN);
 
     // Set file modified date
     ui->leftModified->setStyleSheet(QStringLiteral(""));
     ui->rightModified->setStyleSheet(QStringLiteral(""));
     if(_videos[_leftVideo]->modified == _videos[_rightVideo]->modified)
     {
-        ui->leftModified->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightModified->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftModified->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightModified->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->modified < _videos[_rightVideo]->modified)
-        ui->leftModified->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftModified->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->modified > _videos[_rightVideo]->modified)
-        ui->rightModified->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightModified->setStyleSheet(TEXT_STYLE_GREEN);
 
     // Set file create date (earlier is better, ie green)
     ui->leftFileCreated->setStyleSheet(QStringLiteral(""));
     ui->rightFileCreated->setStyleSheet(QStringLiteral(""));
     if(_videos[_leftVideo]->_fileCreateDate == _videos[_rightVideo]->_fileCreateDate)
     {
-        ui->leftFileCreated->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightFileCreated->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftFileCreated->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightFileCreated->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->_fileCreateDate < _videos[_rightVideo]->_fileCreateDate)
-        ui->leftFileCreated->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftFileCreated->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->_fileCreateDate > _videos[_rightVideo]->_fileCreateDate)
-        ui->rightFileCreated->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightFileCreated->setStyleSheet(TEXT_STYLE_GREEN);
 
     // Set resolution
     ui->leftResolution->setStyleSheet(QStringLiteral(""));
@@ -493,15 +487,15 @@ void Comparison::highlightBetterProperties() const
     if(_videos[_leftVideo]->width * _videos[_leftVideo]->height ==
        _videos[_rightVideo]->width * _videos[_rightVideo]->height)
     {
-        ui->leftResolution->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
-        ui->rightResolution->setStyleSheet(QStringLiteral("QLabel { color : peru; }"));
+        ui->leftResolution->setStyleSheet(TEXT_STYLE_ORANGE);
+        ui->rightResolution->setStyleSheet(TEXT_STYLE_ORANGE);
     }
     else if(_videos[_leftVideo]->width * _videos[_leftVideo]->height >
        _videos[_rightVideo]->width * _videos[_rightVideo]->height)
-        ui->leftResolution->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->leftResolution->setStyleSheet(TEXT_STYLE_GREEN);
     else if(_videos[_leftVideo]->width * _videos[_leftVideo]->height <
             _videos[_rightVideo]->width * _videos[_rightVideo]->height)
-        ui->rightResolution->setStyleSheet(QStringLiteral("QLabel { color : green; }"));
+        ui->rightResolution->setStyleSheet(TEXT_STYLE_GREEN);
 
     // show if video codecs are the same
     ui->leftCodec->setStyleSheet("");
@@ -519,19 +513,12 @@ void Comparison::highlightBetterProperties() const
         ui->rightAudio->setStyleSheet(TEXT_STYLE_ORANGE);
     }
 
-    // Add these lines for GPS Coordinates styling
-    ui->leftGpsCoordinates->setStyleSheet(QStringLiteral(""));
-    ui->rightGpsCoordinates->setStyleSheet(QStringLiteral(""));
-    if (!_videos[_leftVideo]->meta.gpsCoordinates.isEmpty() &&
-        _videos[_leftVideo]->meta.gpsCoordinates == _videos[_rightVideo]->meta.gpsCoordinates) {
-        ui->leftGpsCoordinates->setStyleSheet(TEXT_STYLE_ORANGE);
-        ui->rightGpsCoordinates->setStyleSheet(TEXT_STYLE_ORANGE);
-    } else if (_videos[_leftVideo]->meta.gpsCoordinates.isEmpty() && _videos[_rightVideo]->meta.gpsCoordinates.isEmpty()) {
-        // Both empty, could also style as orange or leave default
-        ui->leftGpsCoordinates->setStyleSheet(QStringLiteral("")); // Default or some indication
-        ui->rightGpsCoordinates->setStyleSheet(QStringLiteral(""));
+    if(!ui->leftGpsCoordinates->text().isEmpty() && ui->rightGpsCoordinates->text().isEmpty()){
+        ui->leftGpsCoordinates->setStyleSheet(TEXT_STYLE_GREEN);
     }
-    // No specific "better" styling for different GPS coordinates
+    else if(ui->leftGpsCoordinates->text().isEmpty() && !ui->rightGpsCoordinates->text().isEmpty()){
+        ui->rightGpsCoordinates->setStyleSheet(TEXT_STYLE_GREEN);
+    }
 }
 
 void Comparison::updateUI()

--- a/QtProject/app/comparison.ui
+++ b/QtProject/app/comparison.ui
@@ -310,6 +310,36 @@
                  </item>
                 </layout>
                </item>
+               <item row="6" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_rightGps">
+                 <item>
+                  <widget class="QLabel" name="labelRightGps">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>GPS:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="rightGpsCoordinates">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
                <item row="2" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayoutLeftFileSize">
                  <item>
@@ -373,7 +403,7 @@
               </layout>
              </item>
              <item>
-              <layout class="QGridLayout" name="gridLayoutLeftDetails" rowstretch="0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0">
+              <layout class="QGridLayout" name="gridLayoutLeftDetails" rowstretch="0,0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0,0">
                <property name="topMargin">
                 <number>0</number>
                </property>
@@ -399,6 +429,36 @@
                   <widget class="QLabel" name="leftDuration">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="6" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_leftGps">
+                 <item>
+                  <widget class="QLabel" name="labelLeftGps">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>GPS:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="leftGpsCoordinates">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
                      <horstretch>0</horstretch>
                      <verstretch>0</verstretch>
                     </sizepolicy>

--- a/QtProject/app/comparison.ui
+++ b/QtProject/app/comparison.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>995</width>
-    <height>650</height>
+    <width>890</width>
+    <height>593</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
      <item>
       <spacer name="horizontalSpacer_6">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -59,10 +59,10 @@
      <item>
       <spacer name="horizontalSpacer_8">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
+        <enum>QSizePolicy::Policy::Expanding</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -100,7 +100,7 @@
         <number>100</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
       </widget>
      </item>
@@ -116,7 +116,7 @@
         <string>1</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
        </property>
       </widget>
      </item>
@@ -168,7 +168,7 @@
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout">
            <property name="sizeConstraint">
-            <enum>QLayout::SetDefaultConstraint</enum>
+            <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
            </property>
            <property name="topMargin">
             <number>0</number>
@@ -199,7 +199,7 @@
                 <string>Click to launch video in default player, scroll mouse wheel to zoom</string>
                </property>
                <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
+                <enum>Qt::LayoutDirection::LeftToRight</enum>
                </property>
                <property name="text" stdset="0">
                 <string/>
@@ -272,7 +272,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -280,10 +280,10 @@
              </item>
              <item>
               <layout class="QGridLayout" name="gridLayoutLeftSizeBrFr">
-               <item row="2" column="3">
-                <layout class="QHBoxLayout" name="horizontalLayoutLeftFrameRate">
+               <item row="2" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayoutLeftBitRate">
                  <item>
-                  <widget class="QLabel" name="labelLeftFrameRate">
+                  <widget class="QLabel" name="labelLeftBitRate">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -291,12 +291,12 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>Frame rate:</string>
+                    <string>Bit rate:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="leftFrameRate">
+                  <widget class="QLabel" name="leftBitRate">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -310,37 +310,7 @@
                  </item>
                 </layout>
                </item>
-               <item row="6" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_rightGps">
-                 <item>
-                  <widget class="QLabel" name="labelRightGps">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>GPS:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="rightGpsCoordinates">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="1">
+               <item row="2" column="0">
                 <layout class="QHBoxLayout" name="horizontalLayoutLeftFileSize">
                  <item>
                   <widget class="QLabel" name="labelLeftFileSize">
@@ -371,9 +341,9 @@
                 </layout>
                </item>
                <item row="2" column="2">
-                <layout class="QHBoxLayout" name="horizontalLayoutLeftBitRate">
+                <layout class="QHBoxLayout" name="horizontalLayoutLeftFrameRate">
                  <item>
-                  <widget class="QLabel" name="labelLeftBitRate">
+                  <widget class="QLabel" name="labelLeftFrameRate">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -381,12 +351,12 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>Bit rate:</string>
+                    <string>Frame rate:</string>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLabel" name="leftBitRate">
+                  <widget class="QLabel" name="leftFrameRate">
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
                      <horstretch>0</horstretch>
@@ -440,36 +410,6 @@
                  </item>
                 </layout>
                </item>
-               <item row="6" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_leftGps">
-                 <item>
-                  <widget class="QLabel" name="labelLeftGps">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>GPS:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="leftGpsCoordinates">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
                <item row="3" column="0">
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
                  <item>
@@ -511,7 +451,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>File created:</string>
+                    <string>Created:</string>
                    </property>
                   </widget>
                  </item>
@@ -601,7 +541,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>File modified:</string>
+                    <string>Modified:</string>
                    </property>
                   </widget>
                  </item>
@@ -619,6 +559,36 @@
                   </widget>
                  </item>
                 </layout>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_leftGps">
+               <item>
+                <widget class="QLabel" name="labelLeftGps">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>GPS:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="leftGpsCoordinates">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
                </item>
               </layout>
              </item>
@@ -717,7 +687,7 @@
                   <string/>
                  </property>
                  <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                  <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
                  </property>
                 </widget>
                </item>
@@ -896,7 +866,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>File created:</string>
+                    <string>Created:</string>
                    </property>
                   </widget>
                  </item>
@@ -1007,6 +977,30 @@
                </item>
               </layout>
              </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_rightGps">
+               <item>
+                <widget class="QLabel" name="labelRightGps">
+                 <property name="text">
+                  <string>GPS:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="rightGpsCoordinates">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
             </layout>
            </item>
           </layout>
@@ -1029,10 +1023,10 @@
            <item>
             <spacer name="horizontalSpacer_4">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Minimum</enum>
+              <enum>QSizePolicy::Policy::Minimum</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1058,7 +1052,7 @@
            <item>
             <spacer name="horizontalSpacer_2">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1087,10 +1081,10 @@
            <item>
             <spacer name="horizontalSpacer_10">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Maximum</enum>
+              <enum>QSizePolicy::Policy::Maximum</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1113,7 +1107,7 @@
            <item>
             <spacer name="horizontalSpacer">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1133,10 +1127,10 @@
            <item>
             <spacer name="horizontalSpacer_5">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Minimum</enum>
+              <enum>QSizePolicy::Policy::Minimum</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1172,7 +1166,7 @@
               </size>
              </property>
              <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
+              <enum>Qt::LayoutDirection::LeftToRight</enum>
              </property>
              <property name="text">
               <string>Swap filenames</string>
@@ -1182,7 +1176,7 @@
            <item>
             <spacer name="horizontalSpacer_11">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1205,7 +1199,7 @@
            <item>
             <spacer name="horizontalSpacer_9">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1218,10 +1212,10 @@
            <item>
             <spacer name="horizontalSpacer_7">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeType">
-              <enum>QSizePolicy::Maximum</enum>
+              <enum>QSizePolicy::Policy::Maximum</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1262,10 +1256,10 @@
          <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Maximum</enum>
+            <enum>QSizePolicy::Policy::Maximum</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1292,21 +1286,21 @@
             <string>Take care,  the following use the comparison threshold,  so be careful to set it as wanted.</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
           </widget>
          </item>
          <item>
           <widget class="Line" name="line_5">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
          <item>
           <widget class="Line" name="line_4">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -1354,10 +1348,10 @@
              <item>
               <spacer name="verticalSpacer">
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
                <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
+                <enum>QSizePolicy::Policy::Fixed</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -1421,7 +1415,7 @@
          <item>
           <widget class="Line" name="line_2">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -1524,7 +1518,7 @@
          <item>
           <widget class="Line" name="line">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
           </widget>
          </item>
@@ -1763,16 +1757,16 @@ In each scenario where only one of the two files is either in a protected folder
               </size>
              </property>
              <property name="contextMenuPolicy">
-              <enum>Qt::CustomContextMenu</enum>
+              <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
              </property>
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right click on the list for more options.&lt;/p&gt;&lt;p&gt;Use up/down arrows to navigate options.&lt;/p&gt;&lt;p&gt;You can also drag and drop to add multiple folders at once.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="verticalScrollBarPolicy">
-              <enum>Qt::ScrollBarAsNeeded</enum>
+              <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
              </property>
              <property name="horizontalScrollBarPolicy">
-              <enum>Qt::ScrollBarAlwaysOn</enum>
+              <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
              </property>
              <property name="showDropIndicator" stdset="0">
               <bool>false</bool>
@@ -1781,16 +1775,16 @@ In each scenario where only one of the two files is either in a protected folder
               <bool>false</bool>
              </property>
              <property name="dragDropMode">
-              <enum>QAbstractItemView::NoDragDrop</enum>
+              <enum>QAbstractItemView::DragDropMode::NoDragDrop</enum>
              </property>
              <property name="selectionMode">
-              <enum>QAbstractItemView::ExtendedSelection</enum>
+              <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
              </property>
              <property name="textElideMode">
-              <enum>Qt::ElideLeft</enum>
+              <enum>Qt::TextElideMode::ElideLeft</enum>
              </property>
              <property name="horizontalScrollMode">
-              <enum>QAbstractItemView::ScrollPerPixel</enum>
+              <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
              </property>
             </widget>
            </item>
@@ -1863,28 +1857,28 @@ In each scenario where only one of the two files is either in a protected folder
               </size>
              </property>
              <property name="contextMenuPolicy">
-              <enum>Qt::CustomContextMenu</enum>
+              <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
              </property>
              <property name="horizontalScrollBarPolicy">
-              <enum>Qt::ScrollBarAlwaysOn</enum>
+              <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
              </property>
              <property name="dragEnabled">
               <bool>true</bool>
              </property>
              <property name="dragDropMode">
-              <enum>QAbstractItemView::InternalMove</enum>
+              <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
              </property>
              <property name="defaultDropAction">
-              <enum>Qt::MoveAction</enum>
+              <enum>Qt::DropAction::MoveAction</enum>
              </property>
              <property name="selectionMode">
-              <enum>QAbstractItemView::ExtendedSelection</enum>
+              <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
              </property>
              <property name="textElideMode">
-              <enum>Qt::ElideLeft</enum>
+              <enum>Qt::TextElideMode::ElideLeft</enum>
              </property>
              <property name="horizontalScrollMode">
-              <enum>QAbstractItemView::ScrollPerPixel</enum>
+              <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
              </property>
              <property name="sortingEnabled">
               <bool>true</bool>
@@ -1929,7 +1923,7 @@ In each scenario where only one of the two files is either in a protected folder
         </sizepolicy>
        </property>
        <property name="frameShape">
-        <enum>QFrame::Box</enum>
+        <enum>QFrame::Shape::Box</enum>
        </property>
        <property name="text">
         <string>Identical bits</string>
@@ -1939,10 +1933,10 @@ In each scenario where only one of the two files is either in a protected folder
      <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
+        <enum>QSizePolicy::Policy::Fixed</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/QtProject/app/comparison.ui
+++ b/QtProject/app/comparison.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>890</width>
-    <height>593</height>
+    <height>597</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -139,8 +139,8 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>100</width>
-       <height>100</height>
+       <width>500</width>
+       <height>500</height>
       </size>
      </property>
      <property name="currentIndex">
@@ -184,7 +184,7 @@
              <item>
               <widget class="ClickableLabel" name="leftImage" native="true">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -279,7 +279,7 @@
               </layout>
              </item>
              <item>
-              <layout class="QGridLayout" name="gridLayoutLeftSizeBrFr">
+              <layout class="QGridLayout" name="gridLayout_leftSizeBitFrame">
                <item row="2" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayoutLeftBitRate">
                  <item>
@@ -373,7 +373,10 @@
               </layout>
              </item>
              <item>
-              <layout class="QGridLayout" name="gridLayoutLeftDetails" rowstretch="0,0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0,0">
+              <layout class="QGridLayout" name="gridLayout_LeftDetails" rowstretch="0,0,0,0,0,0" rowminimumheight="0,0,0,0,0,0">
+               <property name="sizeConstraint">
+                <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+               </property>
                <property name="topMargin">
                 <number>0</number>
                </property>
@@ -567,7 +570,7 @@
                <item>
                 <widget class="QLabel" name="labelLeftGps">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
@@ -580,13 +583,58 @@
                <item>
                 <widget class="QLabel" name="leftGpsCoordinates">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
                  <property name="text">
                   <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_leftMetadata">
+               <property name="spacing">
+                <number>1</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="label_leftMetadata">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Other metadata:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QTextEdit" name="textEdit_leftMetadata">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>70</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>60</height>
+                  </size>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
@@ -602,7 +650,7 @@
              <item>
               <widget class="ClickableLabel" name="rightImage" native="true">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -622,7 +670,7 @@
               </widget>
              </item>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <layout class="QHBoxLayout" name="horizontalLayout_rightFileName">
                <item>
                 <widget class="QLabel" name="label_28">
                  <property name="sizePolicy">
@@ -788,7 +836,7 @@
               </layout>
              </item>
              <item>
-              <layout class="QGridLayout" name="gridLayout_3">
+              <layout class="QGridLayout" name="gridLayout_RightDetails">
                <property name="topMargin">
                 <number>0</number>
                </property>
@@ -981,6 +1029,12 @@
               <layout class="QHBoxLayout" name="horizontalLayout_rightGps">
                <item>
                 <widget class="QLabel" name="labelRightGps">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="text">
                   <string>GPS:</string>
                  </property>
@@ -989,13 +1043,55 @@
                <item>
                 <widget class="QLabel" name="rightGpsCoordinates">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
                  <property name="text">
                   <string/>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_rightMetadata">
+               <property name="spacing">
+                <number>1</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="label_rightMetadata">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Other metadata:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QTextEdit" name="textEdit_rightMetadata">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>70</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>60</height>
+                  </size>
                  </property>
                 </widget>
                </item>

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -1,5 +1,4 @@
 #include "video.h"
-#include <QStringList> // Added for GPS metadata processing
 
 #define FAIL_ON_FRAME_DECODE_NB_FAIL 10
 

--- a/QtProject/app/videometadata.h
+++ b/QtProject/app/videometadata.h
@@ -19,6 +19,7 @@ public:
     QString audio;
     short width = 0;
     short height = 0;
+    QString gpsCoordinates;
 };
 
 #endif // VIDEOMETADATA_H

--- a/QtProject/app/videometadata.h
+++ b/QtProject/app/videometadata.h
@@ -20,6 +20,7 @@ public:
     short width = 0;
     short height = 0;
     QString gpsCoordinates;
+    QMap<QString, QString> fileMetadata;
 };
 
 #endif // VIDEOMETADATA_H

--- a/QtProject/video-simili-duplicate-cleaner.pro.user
+++ b/QtProject/video-simili-duplicate-cleaner.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 16.0.2, 2025-06-09T17:30:44. -->
+<!-- Written by QtCreator 16.0.2, 2025-06-09T18:19:05. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -71,7 +71,14 @@
     <value type="bool" key="AutoTest.Framework.QtTest">true</value>
    </valuemap>
    <value type="bool" key="AutoTest.ApplyFilter">false</value>
-   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates">
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:cleanupTestCase">Unchecked</value>
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:initTestCase">Unchecked</value>
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:cleanupTestCase">Unchecked</value>
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:initTestCase">Unchecked</value>
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:cleanupTestCase">Unchecked</value>
+    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:initTestCase">Unchecked</value>
+   </valuemap>
    <valuelist type="QVariantList" key="AutoTest.PathFilters"/>
    <value type="int" key="AutoTest.RunAfterBuild">0</value>
    <value type="bool" key="AutoTest.UseGlobal">true</value>
@@ -98,7 +105,7 @@
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Qt 6.9.1 for macOS</value>
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Qt 6.9.1 for macOS</value>
    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt6.691.clang_64_kit</value>
-   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="qlonglong" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="qlonglong" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
@@ -109,7 +116,7 @@
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">true</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
       <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
@@ -212,7 +219,7 @@
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/app/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug/app/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.1">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -231,7 +238,7 @@
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_comparison/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug/tests/test_comparison/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.2">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -250,7 +257,7 @@
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_mainwindow/test_mainwindow.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug/tests/test_mainwindow/test_mainwindow.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.3">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -269,7 +276,7 @@
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_video/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug/tests/test_video/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">4</value>
   </valuemap>

--- a/QtProject/video-simili-duplicate-cleaner.pro.user
+++ b/QtProject/video-simili-duplicate-cleaner.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 12.0.2, 2025-04-06T10:36:20. -->
+<!-- Written by QtCreator 16.0.2, 2025-06-09T17:30:44. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -8,13 +8,13 @@
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
-  <value type="qlonglong">1</value>
+  <value type="qlonglong">0</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.EditorSettings</variable>
   <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoDetect">true</value>
    <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
-   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
    <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
    <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
     <value type="QString" key="language">Cpp</value>
@@ -33,6 +33,7 @@
    <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
    <value type="int" key="EditorConfiguration.IndentSize">4</value>
    <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.LineEndingBehavior">0</value>
    <value type="int" key="EditorConfiguration.MarginColumn">80</value>
    <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
    <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
@@ -69,35 +70,9 @@
     <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
     <value type="bool" key="AutoTest.Framework.QtTest">true</value>
    </valuemap>
-   <valuemap type="QVariantMap" key="AutoTest.CheckStates">
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:cleanupTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:initTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:test_comparison">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/tst_test_comparison.cpp:test_videoToDelete_OnlyTimeDiffs">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:TestMainWindow">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:cleanupTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:initTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/tst_mainwindow.cpp:test_case1">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:TestVideo">PartiallyChecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:cleanupTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:emptyDb">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:initTestCase">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_cache_manualCompare500Sampled_AcceptSmallDurationDiffs">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_cache_noVisualThumbCheck">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_cache_noVisualThumbCheck_AcceptSmallDurationDiffs_ignoreModifiedDates">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_nocache_manualCompare500Sampled_AcceptSmallDurationDiffs">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_nocache_noVisualThumbCheck">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBcheckRefVidParams_nocache_noVisualThumbCheck_AcceptSmallDurationDiffs_ignoreModifiedDates">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBwholeApp_cached">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_100GBwholeApp_nocache">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_cached_exact_identical">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_cached_manualCompare10Sampled_AcceptSmallDurationDiffs">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_cached_noThumbHashesCheck">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_nocache_exact_identical">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_nocache_manualCompare10Sampled_AcceptSmallDurationDiffs">Unchecked</value>
-    <value type="Qt::CheckState" key="1@/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/tst_video.cpp:test_check_refvidparams_nocache_noThumbHashesCheck">Unchecked</value>
-    <value type="Qt::CheckState" key="1@:Qt Test">PartiallyChecked</value>
-   </valuemap>
+   <value type="bool" key="AutoTest.ApplyFilter">false</value>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <valuelist type="QVariantList" key="AutoTest.PathFilters"/>
    <value type="int" key="AutoTest.RunAfterBuild">0</value>
    <value type="bool" key="AutoTest.UseGlobal">true</value>
    <valuemap type="QVariantMap" key="ClangTools">
@@ -120,16 +95,16 @@
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
    <value type="QString" key="DeviceType">Desktop</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Qt 6.8.1 for macOS</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Qt 6.8.1 for macOS</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt6.681.clang_64_kit</value>
-   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Qt 6.9.1 for macOS</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Qt 6.9.1 for macOS</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt6.691.clang_64_kit</value>
+   <value type="qlonglong" key="ProjectExplorer.Target.ActiveBuildConfiguration">1</value>
    <value type="qlonglong" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="qlonglong" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
     <value type="int" key="EnableQmlDebugging">0</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
@@ -167,13 +142,13 @@
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Release</value>
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">%{ActiveProject:NativePath}/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">true</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
       <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
@@ -229,14 +204,15 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
+    <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph dwarf,4096 -F 250</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/app/app.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:</value>
     <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/app/app.pro</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug/app/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/app/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.1">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -247,14 +223,15 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
+    <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph dwarf,4096 -F 250</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/test_comparison.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:</value>
     <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_comparison/test_comparison.pro</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug/tests/test_comparison/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_comparison/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.2">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -265,14 +242,15 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
+    <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph dwarf,4096 -F 250</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/test_mainwindow.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:</value>
     <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_mainwindow/test_mainwindow.pro</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug/tests/test_mainwindow/test_mainwindow.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_mainwindow/test_mainwindow.app/Contents/MacOS</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.3">
     <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
@@ -283,14 +261,15 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="bool" key="PE.EnvironmentAspect.PrintOnRun">false</value>
+    <value type="QString" key="PerfRecordArgsId">-e cpu-cycles --call-graph dwarf,4096 -F 250</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/test_video.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:</value>
     <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/tests/test_video/test_video.pro</value>
     <value type="bool" key="ProjectExplorer.RunConfiguration.Customized">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_8_1_for_macOS-Debug/tests/test_video/Video simili duplicate cleaner.app/Contents/MacOS</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/theophanemayaud/Dev/video-simili-duplicate-cleaner/QtProject/builds/build-video-simili-duplicate-cleaner-Qt_6_9_1_for_macOS-Release/tests/test_video/Video simili duplicate cleaner.app/Contents/MacOS</value>
    </valuemap>
    <value type="qlonglong" key="ProjectExplorer.Target.RunConfigurationCount">4</value>
   </valuemap>


### PR DESCRIPTION
This pull request introduces enhancements to the `Comparison` class, improves UI consistency, and updates copyright information. The most notable changes involve displaying GPS metadata for videos, refactoring style definitions for better readability, and modifying the layout and properties in the UI file.

### Enhancements to GPS Metadata Display:
* [`QtProject/app/comparison.cpp`](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R76-R81): Added logic to display GPS metadata for videos, including toggling visibility of GPS labels and coordinates based on metadata availability. [[1]](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R76-R81) [[2]](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R363-R379)
* [`QtProject/app/comparison.cpp`](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R528-R534): Updated the `highlightBetterProperties` method to apply green styling for GPS coordinates when one video has GPS data and the other does not.

### Refactoring for Style Definitions:
* [`QtProject/app/comparison.cpp`](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R15): Introduced `TEXT_STYLE_GREEN` and reused `TEXT_STYLE_ORANGE` for consistent styling, replacing inline style definitions across multiple properties. [[1]](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R15) [[2]](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0L402-R494) [[3]](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0L479-R511)

### UI Layout and Property Updates:
* [`QtProject/app/comparison.ui`](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L9-R10): Adjusted dimensions of the main comparison window and updated layout properties for better alignment and spacing. [[1]](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L9-R10) [[2]](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L187-R187)
* [`QtProject/app/comparison.ui`](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L275-R299): Renamed and reorganized layouts (`gridLayoutLeftSizeBrFr` to `gridLayout_leftSizeBitFrame`) and updated widget text for clarity (e.g., "File created" to "Created"). [[1]](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L275-R299) [[2]](diffhunk://#diff-754dcfc2ab33d2dca864d1a8e4565302baaa222843a41b4394cb7c4df1cc32e9L454-R457)

### Copyright Update:
* [`QtProject/app/common.pri`](diffhunk://#diff-ceb64aa98c75fe0eaadf4a5419bafe5d1204029099ecdb13b5c68ac64be711aaL8-R8): Updated copyright year from 2024 to 2025.

These changes collectively improve functionality, maintainability, and user experience within the application.