### PR TITLE
Fix(Shortcuts): Ensure Cmd+W and Cmd+Q work in Comparison Window

### DIFF
--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -72,13 +72,10 @@ Comparison::Comparison(const QVector<Video *> &videosParam, Prefs &prefsParam) :
     QShortcut* upShortcut = new QShortcut(QKeySequence(QKeySequence::MoveToPreviousLine), ui->tabManual);
     connect(upShortcut, SIGNAL(activated()), this, SLOT(on_prevVideo_clicked()));
 
-    // Add Cmd+W shortcut to close the comparison window
-    QShortcut* closeShortcut = new QShortcut(QKeySequence::Close, this);
-    connect(closeShortcut, &QShortcut::activated, this, &Comparison::accept);
-
-    // Add Cmd+Q shortcut to quit the application from the comparison window
-    QShortcut* quitShortcut = new QShortcut(QKeySequence::Quit, this);
-    connect(quitShortcut, &QShortcut::activated, qApp, &QApplication::quit);
+    // Add Cmd+W shortcut to close the comparison window (actually a dialog so closes with accept)
+    connect(new QShortcut(QKeySequence::Close, this), &QShortcut::activated, this, &Comparison::accept);
+    // Cmd+Q shortcut to quit the application from the comparison dialog, not handled by default
+    connect(new QShortcut(QKeySequence::Quit, this), &QShortcut::activated, qApp, &QApplication::quit);
 
     on_nextVideo_clicked();
 }
@@ -145,7 +142,8 @@ void Comparison::confirmToExit()
             emit sendStatusMessage(QStringLiteral("\nComparison window closed because no matching videos found "
                                                  "(a lower threshold may help to find more matches)"));
 
-        this->accept(); // Directly close the dialog
+        QKeyEvent *closeEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+        QApplication::postEvent(this, closeEvent);  //"pressing" ESC closes dialog
     }
 }
 

--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -72,6 +72,14 @@ Comparison::Comparison(const QVector<Video *> &videosParam, Prefs &prefsParam) :
     QShortcut* upShortcut = new QShortcut(QKeySequence(QKeySequence::MoveToPreviousLine), ui->tabManual);
     connect(upShortcut, SIGNAL(activated()), this, SLOT(on_prevVideo_clicked()));
 
+    // Add Cmd+W shortcut to close the comparison window
+    QShortcut* closeShortcut = new QShortcut(QKeySequence::Close, this);
+    connect(closeShortcut, &QShortcut::activated, this, &Comparison::accept);
+
+    // Add Cmd+Q shortcut to quit the application from the comparison window
+    QShortcut* quitShortcut = new QShortcut(QKeySequence::Quit, this);
+    connect(quitShortcut, &QShortcut::activated, qApp, &QApplication::quit);
+
     on_nextVideo_clicked();
 }
 
@@ -137,8 +145,7 @@ void Comparison::confirmToExit()
             emit sendStatusMessage(QStringLiteral("\nComparison window closed because no matching videos found "
                                                  "(a lower threshold may help to find more matches)"));
 
-        QKeyEvent *closeEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
-        QApplication::postEvent(this, closeEvent);  //"pressing" ESC closes dialog
+        this->accept(); // Directly close the dialog
     }
 }
 

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -83,6 +83,9 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     setComparisonMode(this->_prefs.comparisonMode());
 
     setUseCacheOption(this->_prefs.useCacheOption());
+
+    // Add Cmd+W to quit, default cmd+q already handled by qt on mainwindow
+    connect(new QShortcut(QKeySequence::Close, this), &QShortcut::activated, this, &QApplication::quit);
 }
 
 void MainWindow::deleteTemporaryFiles() const


### PR DESCRIPTION
This pull request introduces keyboard shortcuts to improve user experience in the `QtProject` application. Specifically, it adds shortcuts for closing windows and quitting the application in both the comparison dialog and the main window.

### User experience improvements:

* [`QtProject/app/comparison.cpp`](diffhunk://#diff-5758bfdbebc4288bc31a4a1d6e1839a6f3c630c18a0c4ed8e31c2830195b34a0R82-R86): Added Cmd+W shortcut to close the comparison dialog and Cmd+Q shortcut to quit the application directly from the comparison dialog.
* [`QtProject/app/mainwindow.cpp`](diffhunk://#diff-8f8304475eeaf10a9608eb708f0efddd2c79a0799871df4c627ffe8a28937d64R86-R88): Added Cmd+W shortcut to quit the application from the main window. Cmd+Q behavior is already handled by Qt.