### PR TITLE
Fix counter overflows with large number of files

### DIFF
--- a/QtProject/app/comparison.h
+++ b/QtProject/app/comparison.h
@@ -66,6 +66,7 @@ private:
     bool _firstScriptingAskPermission = true;
 
     void seekFromSliderPosition(int position);
+    void setProgressBarValueSafe(int64_t current);
 
     void loadLockedFolderFromPrefs();
     void addLockedFolderToList(QString folderPath);
@@ -124,7 +125,7 @@ private slots:
     QString readableBitRate(const double &kbps) const;
     void highlightBetterProperties() const;
     void updateUI();
-    int comparisonsSoFar() const;
+    int64_t comparisonsSoFar() const;
     void onProgressSliderReleased();
 
     void on_selectPhash_clicked ( const bool &checked) { if(checked) this->_prefs.comparisonMode(Prefs::_PHASH);


### PR DESCRIPTION
Fixes #165. Addresses integer overflow when calculating total comparisons for >46k files by using int64_t and scaling UI progress values.