### PR TITLE
feat(errors): add option to move error videos to specific folder

### DIFF
--- a/QtProject/app/comparison.cpp
+++ b/QtProject/app/comparison.cpp
@@ -899,7 +899,8 @@ void Comparison::deleteVideo(const int &side, const bool auto_trash_mode)
                 }
             }
             else if(_prefs.delMode == Prefs::CUSTOM_TRASH){ // otherwise we move to the custom folder selected by user
-                if(!_prefs.trashDir.exists()){
+                const auto customTrashFolder = _prefs.customTrashFolder();
+                if(!customTrashFolder.exists()){
                     if(!auto_trash_mode)
                         QMessageBox::information(this, "", "Selected folder to move files into doesn't seem to exist");
                     else
@@ -907,9 +908,9 @@ void Comparison::deleteVideo(const int &side, const bool auto_trash_mode)
                     return;
                 }
                 else { // the destination directory does exist
-                    QFileInfo newFileInfo(_prefs.trashDir, QFileInfo(filename).fileName());
+                    QFileInfo newFileInfo(customTrashFolder, QFileInfo(filename).fileName());
                     if(newFileInfo.exists()) // create random name to make sure it doesn't exist
-                        newFileInfo.setFile(_prefs.trashDir, QFileInfo(filename).completeBaseName()+"-"+QUuid::createUuid().toString().remove("{").remove("}") + "." + QFileInfo(filename).suffix());
+                        newFileInfo.setFile(customTrashFolder, QFileInfo(filename).completeBaseName()+"-"+QUuid::createUuid().toString().remove("{").remove("}") + "." + QFileInfo(filename).suffix());
                     if(!QFile(filename).rename(newFileInfo.absoluteFilePath())){ // rename actually moves to new path !
                         if(!auto_trash_mode)
                             QMessageBox::information(this, "", "Could not move file to selected folder. Check file permissions.");

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -82,6 +82,7 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     setComparisonMode(this->_prefs.comparisonMode());
 
     setUseCacheOption(this->_prefs.useCacheOption());
+    restoreCustomTrashFolder();
     updateErrorVideoActions();
 
     // Add Cmd+W to quit, default cmd+q already handled by qt on mainwindow
@@ -600,22 +601,17 @@ void MainWindow::on_actionChange_trash_folder_triggered()
         QMessageBox::information(this, "", "The folder selected doesn't seem to exist, please create it first");
         return;
     }
-    _prefs.trashDir = QDir(dir);
+    _prefs.customTrashFolder(QDir(dir));
     // we successfully set custom trash location
     _prefs.delMode = Prefs::CUSTOM_TRASH;
-    ui->actionChange_trash_folder->setEnabled(false);
-    ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(true);
-    ui->actionRestoreMoveToTrash->setEnabled(true);
-    addStatusMessage(QString("\nRemoved files will be moved to %1 folder instead of trash\n").arg(_prefs.trashDir.absolutePath()));
+    updateTrashActions();
 }
 
 void MainWindow::on_actionEnable_direct_deletion_instead_of_trash_triggered()
 {
     _prefs.delMode = Prefs::DIRECT_DELETION;
-    ui->actionChange_trash_folder->setEnabled(true);
-    ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(false);
-    ui->actionRestoreMoveToTrash->setEnabled(true);
-    addStatusMessage("\nRemoved files will be deleted directly and completely. Be extra careful what you do !\n");
+    _prefs.clearCustomTrashFolder();
+    updateTrashActions();
 }
 
 void MainWindow::on_actionRestoreMoveToTrash_triggered()
@@ -623,11 +619,31 @@ void MainWindow::on_actionRestoreMoveToTrash_triggered()
     // A  click on this button restores the default "trash" as "move to trash" destination
     // here we must restore the default "move to trash" behavior
     _prefs.delMode = Prefs::STANDARD_TRASH;
-    _prefs.trashDir = QDir::root(); //reset to known, controlled state
-    ui->actionChange_trash_folder->setEnabled(true);
-    ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(true);
-    ui->actionRestoreMoveToTrash->setEnabled(false);
+    _prefs.clearCustomTrashFolder();
+    updateTrashActions();
     addStatusMessage(QString("Removed files will be moved to trash"));
+}
+
+void MainWindow::updateTrashActions()
+{
+    ui->actionChange_trash_folder->setEnabled(_prefs.delMode != Prefs::CUSTOM_TRASH);
+    ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(_prefs.delMode != Prefs::DIRECT_DELETION);
+    ui->actionRestoreMoveToTrash->setEnabled(_prefs.delMode != Prefs::STANDARD_TRASH);
+    if (_prefs.delMode == Prefs::CUSTOM_TRASH) {
+        addStatusMessage(QString("Removed files will be moved to %1 folder instead of trash").arg(_prefs.customTrashFolder().absolutePath()));
+    }
+    else if (_prefs.delMode == Prefs::DIRECT_DELETION) {
+        addStatusMessage("Removed files will be deleted directly and completely. Be extra careful what you do !");
+    }
+}
+
+void MainWindow::restoreCustomTrashFolder()
+{
+    if(!_prefs.hasCustomTrashFolder())
+        return;
+
+    _prefs.delMode = Prefs::CUSTOM_TRASH;
+    updateTrashActions();
 }
 // ------------------- END: File deletion configuration methods -----------
 // ------------------------------------------------------------------------
@@ -647,12 +663,10 @@ void MainWindow::updateErrorVideoActions()
 
 void MainWindow::on_actionSelect_folder_to_move_error_videos_triggered()
 {
-    QString dir = this->_prefs.moveErrorVideosToFolder().absolutePath();
-
-    dir = QFileDialog::getExistingDirectory(ui->browseFolders,
-                                            QByteArrayLiteral("Open folder"),
-                                            dir /*defines where the chooser opens at*/,
-                                            QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+    QString dir = QFileDialog::getExistingDirectory(ui->browseFolders,
+                                                    QByteArrayLiteral("Open folder"),
+                                                    QStandardPaths::standardLocations(QStandardPaths::MoviesLocation).first() /*defines where the chooser opens at*/,
+                                                    QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     if(dir.isEmpty()){ //empty because error or none chosen in dialog
         QMessageBox::information(this, "", "The folder selected seems not defined, try another one");
         return;

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -589,9 +589,10 @@ void MainWindow::on_actionChange_trash_folder_triggered()
 {
     // initially, files will be moved to trash. With this button, another folder can be selected
     // into which to move files upon removal, instead of trash.
+    const auto standardVideosFolders = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation);
     QString dir = QFileDialog::getExistingDirectory(ui->browseFolders,
                                                     QByteArrayLiteral("Open folder"),
-                                                    QStandardPaths::standardLocations(QStandardPaths::MoviesLocation).first() /*defines where the chooser opens at*/,
+                                                    standardVideosFolders.isEmpty() ? QDir::homePath() : standardVideosFolders.first() /*defines where the chooser opens at*/,
                                                     QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     if(dir.isEmpty()){ //empty because error or none chosen in dialog
         QMessageBox::information(this, "", "The folder selected seems not defined, try another one");
@@ -663,9 +664,10 @@ void MainWindow::updateErrorVideoActions()
 
 void MainWindow::on_actionSelect_folder_to_move_error_videos_triggered()
 {
+    const auto standardVideosFolders = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation);
     QString dir = QFileDialog::getExistingDirectory(ui->browseFolders,
                                                     QByteArrayLiteral("Open folder"),
-                                                    QStandardPaths::standardLocations(QStandardPaths::MoviesLocation).first() /*defines where the chooser opens at*/,
+                                                    standardVideosFolders.isEmpty() ? QDir::homePath() : standardVideosFolders.first() /*defines where the chooser opens at*/,
                                                     QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     if(dir.isEmpty()){ //empty because error or none chosen in dialog
         QMessageBox::information(this, "", "The folder selected seems not defined, try another one");
@@ -734,9 +736,10 @@ void MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
             return;
         }
     }
-    if(!QFile(filePathName).rename(newFileInfo.absoluteFilePath())){
-        addStatusMessage(QString("Error moving %1 to selected error videos folder. Check file permissions.")
-                             .arg(QDir::toNativeSeparators(filePathName)));
+    QFile sourceFile(filePathName);
+    if(!sourceFile.rename(newFileInfo.absoluteFilePath())){
+        addStatusMessage(QString("Error moving %1 to selected error videos folder: %2")
+                             .arg(QDir::toNativeSeparators(filePathName), sourceFile.errorString()));
         return;
     }
 

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -82,6 +82,7 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     setComparisonMode(this->_prefs.comparisonMode());
 
     setUseCacheOption(this->_prefs.useCacheOption());
+    setErrorVideoMode(this->_prefs.errorVideoMode());
 
     // Add Cmd+W to quit, default cmd+q already handled by qt on mainwindow
     connect(new QShortcut(QKeySequence::Close, this), &QShortcut::activated, this, &QApplication::quit);
@@ -333,7 +334,7 @@ void MainWindow::processVideos()
     } else
         addStatusMessage(QString("Using %1 threads for video processing.").arg(maxParallelTasks));
     // maxParallelTasks = 1; // for local debugging if parallelism is causing issues
-    
+
     for(auto &vidIter : sortedVids) {
         // Wait if we have too many active tasks
         while(activeFutures.size() >= 2*maxParallelTasks) { // double to schedule some tasks in advance so QT can immediately run them when a thread frees up
@@ -362,15 +363,15 @@ void MainWindow::processVideos()
             return video->process();
         });
         activeFutures.append(future);
-        
+
         QApplication::processEvents();
     }
 
     // Wait for all remaining futures to complete
     QProgressDialog progress("Waiting for video(s) still processing", QString(), 0, activeFutures.size(), this);
     progress.setWindowModality(Qt::WindowModal);
-    
-    // Process remaining futures 
+
+    // Process remaining futures
     // Start timer so that if it takes too long, we simply ignore the remaining ones
     // Leading to a small memory leak, but it's not a big deal as it's only a few videos.
     QElapsedTimer timer;
@@ -380,7 +381,7 @@ void MainWindow::processVideos()
             this->ui->findDuplicates->setText(QStringLiteral("Stopping..."));
             this->ui->findDuplicates->setDisabled(true);
         }
-    
+
         for(int i = activeFutures.size() - 1; i >= 0; --i) { // reverse iteration as we remove in place from list
             if(activeFutures[i].isFinished()) {
                 Video::ProcessingResult result = activeFutures.takeAt(i).result();
@@ -487,6 +488,8 @@ void MainWindow::removeVideo(Video *deleteMe, QString errorMsg)
         ui->progressBar->setValue(ui->progressBar->value() + 1);
         ui->processedFiles->setText(QStringLiteral("%1/%2").arg(ui->progressBar->value()).arg(ui->progressBar->maximum()));
         _rejectedVideos << QDir::toNativeSeparators(deleteMe->_filePathName);
+        if(_prefs.errorVideoMode() == Prefs::MOVE_ERROR_VIDEOS)
+            moveErrorVideoToSelectedFolder(deleteMe->_filePathName);
         delete deleteMe;
     }
     else{
@@ -523,6 +526,7 @@ void MainWindow::on_actionRestore_all_settings_triggered()
     on_actionRestore_default_cache_location_triggered();
 
     on_actionRestoreMoveToTrash_triggered();
+    on_actionRestore_simple_skip_of_error_videos_triggered();
     ui->verboseCheckbox->setCheckState(Qt::Unchecked);
 
     this->ui->directoryBox->clear();
@@ -622,6 +626,105 @@ void MainWindow::on_actionRestoreMoveToTrash_triggered()
     addStatusMessage(QString("\nRemoved files will now be moved to trash\n"));
 }
 // ------------------- END: File deletion configuration methods -----------
+// ------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// ------------------- BEGIN: Error video handling configuration methods ------
+void MainWindow::setErrorVideoMode(Prefs::ErrorVideoModes mode)
+{
+    _prefs.errorVideoMode(mode);
+    const bool moveErrorVideos = mode == Prefs::MOVE_ERROR_VIDEOS;
+    ui->actionSelect_folder_to_move_error_videos->setEnabled(!moveErrorVideos);
+    ui->actionRestore_simple_skip_of_error_videos->setEnabled(moveErrorVideos);
+}
+
+void MainWindow::on_actionSelect_folder_to_move_error_videos_triggered()
+{
+    auto currentErrorFolder = this->_prefs.errorVideosFolder();
+    QString dir = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation).first();
+    if(_prefs.errorVideoMode() == Prefs::MOVE_ERROR_VIDEOS && currentErrorFolder.exists())
+        dir = currentErrorFolder.absolutePath();
+
+    dir = QFileDialog::getExistingDirectory(ui->browseFolders,
+                                            QByteArrayLiteral("Open folder"),
+                                            dir /*defines where the chooser opens at*/,
+                                            QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+    if(dir.isEmpty()){ //empty because error or none chosen in dialog
+        QMessageBox::information(this, "", "The folder selected seems not defined, try another one");
+        return;
+    }
+    if(!QDir(dir).exists()){
+        QMessageBox::information(this, "", "The folder selected doesn't seem to exist, please create it first");
+        return;
+    }
+
+    _prefs.errorVideosFolder(QDir(dir));
+    setErrorVideoMode(Prefs::MOVE_ERROR_VIDEOS);
+    addStatusMessage(QString("\nError videos will now be moved to %1\n").arg(QDir(dir).absolutePath()));
+}
+
+void MainWindow::on_actionRestore_simple_skip_of_error_videos_triggered()
+{
+    _prefs.errorVideosFolder(QDir::root());
+    setErrorVideoMode(Prefs::SKIP_ERROR_VIDEOS);
+    addStatusMessage(QString("\nError videos will now be skipped and left untouched\n"));
+}
+
+bool MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
+{
+#ifdef Q_OS_MACOS
+    if(filePathName.contains(".photoslibrary")){
+        addStatusMessage(QString("Skipped moving Apple Photos Library error video %1")
+                             .arg(QDir::toNativeSeparators(filePathName)));
+        return false;
+    }
+#endif
+    const auto errorVideosFolder = _prefs.errorVideosFolder();
+    if(!errorVideosFolder.exists()){
+        addStatusMessage(QString("Error moving %1: selected error videos folder does not exist")
+                             .arg(QDir::toNativeSeparators(filePathName)));
+        return false;
+    }
+
+    const QFileInfo fileInfo(filePathName);
+    if(!fileInfo.exists()){
+        addStatusMessage(QString("Error moving %1: file does not exist")
+                             .arg(QDir::toNativeSeparators(filePathName)));
+        return false;
+    }
+
+    QFileInfo newFileInfo(errorVideosFolder, fileInfo.fileName());
+    if(newFileInfo.exists()){
+        bool foundAvailableName = false;
+        for(int suffix = 1; suffix <= 100; suffix++){
+            QString replacementName = QStringLiteral("%1-%2").arg(fileInfo.completeBaseName()).arg(suffix);
+            if(!fileInfo.suffix().isEmpty())
+                replacementName += "." + fileInfo.suffix();
+            newFileInfo.setFile(errorVideosFolder, replacementName);
+            if(!newFileInfo.exists()){
+                foundAvailableName = true;
+                break;
+            }
+        }
+        if(!foundAvailableName){
+            addStatusMessage(QString("Error moving %1: could not find an available filename in selected error videos folder")
+                                 .arg(QDir::toNativeSeparators(filePathName)));
+            return false;
+        }
+    }
+    if(!QFile(filePathName).rename(newFileInfo.absoluteFilePath())){
+        addStatusMessage(QString("Error moving %1 to selected error videos folder. Check file permissions.")
+                             .arg(QDir::toNativeSeparators(filePathName)));
+        return false;
+    }
+
+    Db(_prefs.cacheFilePathName()).removeVideo(filePathName);
+    addStatusMessage(QString("Moved error video %1 to %2")
+                         .arg(QDir::toNativeSeparators(filePathName),
+                              QDir::toNativeSeparators(newFileInfo.absoluteFilePath())));
+    return true;
+}
+// ------------------- END: Error video configuration methods -----------
 // ----------------------------------------------------------------------------
 
 void MainWindow::on_actionDelete_log_files_triggered()

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -670,27 +670,27 @@ void MainWindow::on_actionRestore_simple_skip_of_error_videos_triggered()
     addStatusMessage(QString("\nError videos will now be skipped and left untouched\n"));
 }
 
-bool MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
+void MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
 {
 #ifdef Q_OS_MACOS
     if(filePathName.contains(".photoslibrary")){
         addStatusMessage(QString("Skipped moving Apple Photos Library error video %1")
                              .arg(QDir::toNativeSeparators(filePathName)));
-        return false;
+        return;
     }
 #endif
     const auto errorVideosFolder = _prefs.errorVideosFolder();
     if(!errorVideosFolder.exists()){
         addStatusMessage(QString("Error moving %1: selected error videos folder does not exist")
                              .arg(QDir::toNativeSeparators(filePathName)));
-        return false;
+        return;
     }
 
     const QFileInfo fileInfo(filePathName);
     if(!fileInfo.exists()){
         addStatusMessage(QString("Error moving %1: file does not exist")
                              .arg(QDir::toNativeSeparators(filePathName)));
-        return false;
+        return;
     }
 
     QFileInfo newFileInfo(errorVideosFolder, fileInfo.fileName());
@@ -709,20 +709,19 @@ bool MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
         if(!foundAvailableName){
             addStatusMessage(QString("Error moving %1: could not find an available filename in selected error videos folder")
                                  .arg(QDir::toNativeSeparators(filePathName)));
-            return false;
+            return;
         }
     }
     if(!QFile(filePathName).rename(newFileInfo.absoluteFilePath())){
         addStatusMessage(QString("Error moving %1 to selected error videos folder. Check file permissions.")
                              .arg(QDir::toNativeSeparators(filePathName)));
-        return false;
+        return;
     }
 
     Db(_prefs.cacheFilePathName()).removeVideo(filePathName);
     addStatusMessage(QString("Moved error video %1 to %2")
                          .arg(QDir::toNativeSeparators(filePathName),
                               QDir::toNativeSeparators(newFileInfo.absoluteFilePath())));
-    return true;
 }
 // ------------------- END: Error video configuration methods -----------
 // ----------------------------------------------------------------------------

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -82,7 +82,7 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     setComparisonMode(this->_prefs.comparisonMode());
 
     setUseCacheOption(this->_prefs.useCacheOption());
-    setErrorVideoMode(this->_prefs.errorVideoMode());
+    updateErrorVideoActions();
 
     // Add Cmd+W to quit, default cmd+q already handled by qt on mainwindow
     connect(new QShortcut(QKeySequence::Close, this), &QShortcut::activated, this, &QApplication::quit);
@@ -521,6 +521,8 @@ void MainWindow::on_actionSet_custom_cache_location_triggered()
 
 void MainWindow::on_actionRestore_all_settings_triggered()
 {
+    addStatusMessage("\nRestoring all settings...");
+
     this->_prefs.resetSettings();
 
     on_actionRestore_default_cache_location_triggered();
@@ -538,15 +540,17 @@ void MainWindow::on_actionRestore_all_settings_triggered()
     setMatchSimilarityThreshold(this->_prefs.matchSimilarityThreshold());
 
     setUseCacheOption(this->_prefs.useCacheOption());
+
+    addStatusMessage(""); // empty new line after all settings cleared messages
 }
 
 void MainWindow::on_actionRestore_default_cache_location_triggered()
 {
     _prefs.cacheFilePathName("");
     if(Db::initDbAndCacheLocation(_prefs))
-        addStatusMessage("\nCache restored to: " + _prefs.cacheFilePathName() + "\n");
+        addStatusMessage("Cache restored to: " + _prefs.cacheFilePathName());
     else
-        addStatusMessage(QString("\nError restoring default cache. Probably no cache now.\n"));
+        addStatusMessage("Error restoring default cache. Probably no cache now.");
 }
 
 void MainWindow::on_actionCredits_triggered()
@@ -602,7 +606,7 @@ void MainWindow::on_actionChange_trash_folder_triggered()
     ui->actionChange_trash_folder->setEnabled(false);
     ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(true);
     ui->actionRestoreMoveToTrash->setEnabled(true);
-    addStatusMessage(QString("\nRemoved files will now be moved to %1 folder instead of trash\n").arg(_prefs.trashDir.absolutePath()));
+    addStatusMessage(QString("\nRemoved files will be moved to %1 folder instead of trash\n").arg(_prefs.trashDir.absolutePath()));
 }
 
 void MainWindow::on_actionEnable_direct_deletion_instead_of_trash_triggered()
@@ -611,7 +615,7 @@ void MainWindow::on_actionEnable_direct_deletion_instead_of_trash_triggered()
     ui->actionChange_trash_folder->setEnabled(true);
     ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(false);
     ui->actionRestoreMoveToTrash->setEnabled(true);
-    addStatusMessage("\nRemoved files will now be deleted directly and completely. Be extra careful what you do !\n");
+    addStatusMessage("\nRemoved files will be deleted directly and completely. Be extra careful what you do !\n");
 }
 
 void MainWindow::on_actionRestoreMoveToTrash_triggered()
@@ -623,27 +627,27 @@ void MainWindow::on_actionRestoreMoveToTrash_triggered()
     ui->actionChange_trash_folder->setEnabled(true);
     ui->actionEnable_direct_deletion_instead_of_trash->setEnabled(true);
     ui->actionRestoreMoveToTrash->setEnabled(false);
-    addStatusMessage(QString("\nRemoved files will now be moved to trash\n"));
+    addStatusMessage(QString("Removed files will be moved to trash"));
 }
 // ------------------- END: File deletion configuration methods -----------
 // ------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 // ------------------- BEGIN: Error video handling configuration methods ------
-void MainWindow::setErrorVideoMode(Prefs::ErrorVideoModes mode)
+void MainWindow::updateErrorVideoActions()
 {
-    _prefs.errorVideoMode(mode);
-    const bool moveErrorVideos = mode == Prefs::MOVE_ERROR_VIDEOS;
+    const bool moveErrorVideos = _prefs.errorVideoMode() == Prefs::MOVE_ERROR_VIDEOS;
     ui->actionSelect_folder_to_move_error_videos->setEnabled(!moveErrorVideos);
     ui->actionRestore_simple_skip_of_error_videos->setEnabled(moveErrorVideos);
+
+    if (moveErrorVideos) {
+        addStatusMessage(QString("Error videos will be moved to %1").arg(_prefs.moveErrorVideosToFolder().absolutePath()));
+    }
 }
 
 void MainWindow::on_actionSelect_folder_to_move_error_videos_triggered()
 {
-    auto currentErrorFolder = this->_prefs.errorVideosFolder();
-    QString dir = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation).first();
-    if(_prefs.errorVideoMode() == Prefs::MOVE_ERROR_VIDEOS && currentErrorFolder.exists())
-        dir = currentErrorFolder.absolutePath();
+    QString dir = this->_prefs.moveErrorVideosToFolder().absolutePath();
 
     dir = QFileDialog::getExistingDirectory(ui->browseFolders,
                                             QByteArrayLiteral("Open folder"),
@@ -658,16 +662,15 @@ void MainWindow::on_actionSelect_folder_to_move_error_videos_triggered()
         return;
     }
 
-    _prefs.errorVideosFolder(QDir(dir));
-    setErrorVideoMode(Prefs::MOVE_ERROR_VIDEOS);
-    addStatusMessage(QString("\nError videos will now be moved to %1\n").arg(QDir(dir).absolutePath()));
+    _prefs.moveErrorVideosToFolder(QDir(dir));
+    updateErrorVideoActions();
 }
 
 void MainWindow::on_actionRestore_simple_skip_of_error_videos_triggered()
 {
-    _prefs.errorVideosFolder(QDir::root());
-    setErrorVideoMode(Prefs::SKIP_ERROR_VIDEOS);
-    addStatusMessage(QString("\nError videos will now be skipped and left untouched\n"));
+    _prefs.clearErrorVideosFolder();
+    updateErrorVideoActions();
+    addStatusMessage(QString("Error videos will now be skipped and left untouched"));
 }
 
 void MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
@@ -679,8 +682,13 @@ void MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
         return;
     }
 #endif
-    const auto errorVideosFolder = _prefs.errorVideosFolder();
-    if(!errorVideosFolder.exists()){
+    if(_prefs.errorVideoMode() == Prefs::SKIP_ERROR_VIDEOS){
+        addStatusMessage(QString("Error moving %1: no error videos folder is selected")
+                             .arg(QDir::toNativeSeparators(filePathName)));
+        return;
+    }
+    const QDir moveErrorVideosToFolder = _prefs.moveErrorVideosToFolder();
+    if(!moveErrorVideosToFolder.exists()){
         addStatusMessage(QString("Error moving %1: selected error videos folder does not exist")
                              .arg(QDir::toNativeSeparators(filePathName)));
         return;
@@ -693,14 +701,14 @@ void MainWindow::moveErrorVideoToSelectedFolder(const QString &filePathName)
         return;
     }
 
-    QFileInfo newFileInfo(errorVideosFolder, fileInfo.fileName());
+    QFileInfo newFileInfo(moveErrorVideosToFolder, fileInfo.fileName());
     if(newFileInfo.exists()){
         bool foundAvailableName = false;
         for(int suffix = 1; suffix <= 100; suffix++){
             QString replacementName = QStringLiteral("%1-%2").arg(fileInfo.completeBaseName()).arg(suffix);
             if(!fileInfo.suffix().isEmpty())
                 replacementName += "." + fileInfo.suffix();
-            newFileInfo.setFile(errorVideosFolder, replacementName);
+            newFileInfo.setFile(moveErrorVideosToFolder, replacementName);
             if(!newFileInfo.exists()){
                 foundAvailableName = true;
                 break;

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -79,7 +79,7 @@ private slots:
     void on_actionRestoreMoveToTrash_triggered();
 
     // error video options: setting to just leave as is (skip) or move to selected folder (move)
-    void setErrorVideoMode(Prefs::ErrorVideoModes mode);
+    void updateErrorVideoActions();
     void moveErrorVideoToSelectedFolder(const QString &filePathName);
     void on_actionSelect_folder_to_move_error_videos_triggered();
     void on_actionRestore_simple_skip_of_error_videos_triggered();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -80,7 +80,7 @@ private slots:
 
     // error video options: setting to just leave as is (skip) or move to selected folder (move)
     void setErrorVideoMode(Prefs::ErrorVideoModes mode);
-    bool moveErrorVideoToSelectedFolder(const QString &filePathName);
+    void moveErrorVideoToSelectedFolder(const QString &filePathName);
     void on_actionSelect_folder_to_move_error_videos_triggered();
     void on_actionRestore_simple_skip_of_error_videos_triggered();
 

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -74,9 +74,13 @@ private slots:
     void on_actionCredits_triggered();
     void on_actionContact_triggered();
 
+    // trash options: select folder instead of trash, enable direct deletion instead of trash, restore move to trash
+    // Only custom trash folder restores on restart, as direct deletion is too dangerous to restore automatically
     void on_actionChange_trash_folder_triggered();
     void on_actionEnable_direct_deletion_instead_of_trash_triggered();
     void on_actionRestoreMoveToTrash_triggered();
+    void updateTrashActions();
+    void restoreCustomTrashFolder();
 
     // error video options: setting to just leave as is (skip) or move to selected folder (move)
     void updateErrorVideoActions();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -78,6 +78,12 @@ private slots:
     void on_actionEnable_direct_deletion_instead_of_trash_triggered();
     void on_actionRestoreMoveToTrash_triggered();
 
+    // error video options: setting to just leave as is (skip) or move to selected folder (move)
+    void setErrorVideoMode(Prefs::ErrorVideoModes mode);
+    bool moveErrorVideoToSelectedFolder(const QString &filePathName);
+    void on_actionSelect_folder_to_move_error_videos_triggered();
+    void on_actionRestore_simple_skip_of_error_videos_triggered();
+
     void on_actionEmpty_cache_triggered();
     void on_actionSet_custom_cache_location_triggered();
     void on_actionRestore_default_cache_location_triggered();

--- a/QtProject/app/mainwindow.ui
+++ b/QtProject/app/mainwindow.ui
@@ -552,6 +552,9 @@
     <addaction name="actionEnable_direct_deletion_instead_of_trash"/>
     <addaction name="actionRestoreMoveToTrash"/>
     <addaction name="separator"/>
+    <addaction name="actionSelect_folder_to_move_error_videos"/>
+    <addaction name="actionRestore_simple_skip_of_error_videos"/>
+    <addaction name="separator"/>
     <addaction name="actionOpen_logs_folder"/>
     <addaction name="actionDelete_log_files"/>
     <addaction name="separator"/>
@@ -647,6 +650,19 @@
   <action name="actionDelete_log_files">
    <property name="text">
     <string>Delete log files</string>
+   </property>
+  </action>
+  <action name="actionSelect_folder_to_move_error_videos">
+   <property name="text">
+    <string>Select folder to move error videos</string>
+   </property>
+  </action>
+  <action name="actionRestore_simple_skip_of_error_videos">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Restore simple skip of error videos</string>
    </property>
   </action>
  </widget>

--- a/QtProject/app/prefs.h
+++ b/QtProject/app/prefs.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QDir>
 #include <QSettings>
+#include <QStandardPaths>
 
 #include "thumbnail.h"
 
@@ -62,37 +63,36 @@ public:
     enum ErrorVideoModes { SKIP_ERROR_VIDEOS, MOVE_ERROR_VIDEOS };
 
     ErrorVideoModes errorVideoMode() const {
-        if(this->errorVideoModeStatic == nullptr){
-            auto readOk = false;
-            auto mode = static_cast<ErrorVideoModes>(QSettings(APP_NAME, APP_NAME).value("error_video_mode").toInt(&readOk));
-            if(!readOk)
-                mode = SKIP_ERROR_VIDEOS;
-            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
-        }
-        return *this->errorVideoModeStatic;
-    }
-    void errorVideoMode(const ErrorVideoModes mode) {
-        if(this->errorVideoModeStatic == nullptr)
-            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
-        else
-            *this->errorVideoModeStatic = mode;
-        QSettings(APP_NAME, APP_NAME).setValue("error_video_mode", mode);
+        return QSettings(APP_NAME, APP_NAME).contains("error_videos_folder") ? MOVE_ERROR_VIDEOS : SKIP_ERROR_VIDEOS;
     }
 
-    QDir errorVideosFolder() const {
+    // Only call this after ensuring errorVideoMode() is set to MOVE_ERROR_VIDEOS
+    // Otherwise will return the standard videos folder
+    QDir moveErrorVideosToFolder() const {
         if(this->errorVideosFolderStatic == nullptr){
-            const auto path = QSettings(APP_NAME, APP_NAME).value("error_videos_folder").toString();
-            auto dir = path.isEmpty() ? QDir::root() : QDir(path);
+            auto settings = QSettings(APP_NAME, APP_NAME);
+            auto dir = QDir();
+            if(settings.contains("error_videos_folder")) {
+                dir = QDir(settings.value("error_videos_folder").toString());
+            } else {
+                // This should never happen, and is actually invalid state
+                const auto standardVideosFolders = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation);
+                dir = QDir(standardVideosFolders.isEmpty() ? QDir::homePath() : standardVideosFolders.first());
+            }
             this->errorVideosFolderStatic = std::make_unique<QDir>(dir);
         }
         return *this->errorVideosFolderStatic;
     }
-    void errorVideosFolder(const QDir dir) {
+    void moveErrorVideosToFolder(const QDir dir) {
         if(this->errorVideosFolderStatic == nullptr)
             this->errorVideosFolderStatic = std::make_unique<QDir>(dir);
         else
             *this->errorVideosFolderStatic = dir;
         QSettings(APP_NAME, APP_NAME).setValue("error_videos_folder", dir.absolutePath());
+    }
+    void clearErrorVideosFolder() {
+        this->errorVideosFolderStatic = nullptr;
+        QSettings(APP_NAME, APP_NAME).remove("error_videos_folder");
     }
 
     // Cache options: no cache, with cache, or cache only
@@ -215,7 +215,6 @@ public:
         this->useCacheOptionStatic = nullptr;
         this->verboseStatic = nullptr;
         this->sortCriterionStatic = nullptr;
-        this->errorVideoModeStatic = nullptr;
         this->errorVideosFolderStatic = nullptr;
         QSettings(APP_NAME, APP_NAME).clear();
     }
@@ -226,7 +225,6 @@ private:
     inline static std::unique_ptr<USE_CACHE_OPTION> useCacheOptionStatic = nullptr;
     inline static std::unique_ptr<bool> verboseStatic = nullptr;
     inline static std::unique_ptr<SortCriterion> sortCriterionStatic = nullptr;
-    inline static std::unique_ptr<ErrorVideoModes> errorVideoModeStatic = nullptr;
     inline static std::unique_ptr<QDir> errorVideosFolderStatic = nullptr;
 };
 

--- a/QtProject/app/prefs.h
+++ b/QtProject/app/prefs.h
@@ -60,7 +60,10 @@ public:
 
     bool hasCustomTrashFolder() const {
         if(this->customTrashFolderConfiguredStatic == nullptr){
-            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(QSettings(APP_NAME, APP_NAME).contains("custom_trash_folder"));
+            auto settings = QSettings(APP_NAME, APP_NAME);
+            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(
+                settings.contains("custom_trash_folder")
+                && !settings.value("custom_trash_folder").toString().isEmpty());
         }
         return *this->customTrashFolderConfiguredStatic;
     }
@@ -105,7 +108,11 @@ public:
 
     ErrorVideoModes errorVideoMode() const {
         if(this->errorVideoModeStatic == nullptr){
-            const auto mode = QSettings(APP_NAME, APP_NAME).contains("error_videos_folder") ? MOVE_ERROR_VIDEOS : SKIP_ERROR_VIDEOS;
+            auto settings = QSettings(APP_NAME, APP_NAME);
+            const auto mode = settings.contains("error_videos_folder")
+                                  && !settings.value("error_videos_folder").toString().isEmpty()
+                                  ? MOVE_ERROR_VIDEOS
+                                  : SKIP_ERROR_VIDEOS;
             this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
         }
         return *this->errorVideoModeStatic;
@@ -282,11 +289,11 @@ private:
     inline static std::unique_ptr<USE_CACHE_OPTION> useCacheOptionStatic = nullptr;
     inline static std::unique_ptr<bool> verboseStatic = nullptr;
     inline static std::unique_ptr<SortCriterion> sortCriterionStatic = nullptr;
-    // To know wether the custom trash folder setting was loaded from QSettings we need an extra flag
+    // To know whether the custom trash folder setting was loaded from QSettings we need an extra flag
     // because a QDir has no good state of "initialized but no value", it would just be root directory
     inline static std::unique_ptr<bool> customTrashFolderConfiguredStatic = nullptr;
     inline static std::unique_ptr<QDir> customTrashFolderStatic = nullptr;
-    // Similar for error video folder: we need an extra flag to differenciate between not loaded vs loaded from QSettings
+    // Similar for error video folder: we need an extra flag to differentiate between not loaded vs loaded from QSettings
     inline static std::unique_ptr<ErrorVideoModes> errorVideoModeStatic = nullptr;
     inline static std::unique_ptr<QDir> errorVideosFolderStatic = nullptr;
 };

--- a/QtProject/app/prefs.h
+++ b/QtProject/app/prefs.h
@@ -61,9 +61,13 @@ public:
     bool hasCustomTrashFolder() const {
         if(this->customTrashFolderConfiguredStatic == nullptr){
             auto settings = QSettings(APP_NAME, APP_NAME);
-            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(
-                settings.contains("custom_trash_folder")
-                && !settings.value("custom_trash_folder").toString().isEmpty());
+            bool hasConfiguredFolder = false;
+            if(settings.contains("custom_trash_folder")){
+                hasConfiguredFolder = QDir(settings.value("custom_trash_folder").toString()).exists();
+                if(!hasConfiguredFolder)
+                    settings.remove("custom_trash_folder");
+            }
+            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(hasConfiguredFolder);
         }
         return *this->customTrashFolderConfiguredStatic;
     }
@@ -109,10 +113,14 @@ public:
     ErrorVideoModes errorVideoMode() const {
         if(this->errorVideoModeStatic == nullptr){
             auto settings = QSettings(APP_NAME, APP_NAME);
-            const auto mode = settings.contains("error_videos_folder")
-                                  && !settings.value("error_videos_folder").toString().isEmpty()
-                                  ? MOVE_ERROR_VIDEOS
-                                  : SKIP_ERROR_VIDEOS;
+            auto mode = SKIP_ERROR_VIDEOS;
+            if(settings.contains("error_videos_folder")){
+                const bool hasConfiguredFolder = QDir(settings.value("error_videos_folder").toString()).exists();
+                if(hasConfiguredFolder)
+                    mode = MOVE_ERROR_VIDEOS;
+                else
+                    settings.remove("error_videos_folder");
+            }
             this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
         }
         return *this->errorVideoModeStatic;

--- a/QtProject/app/prefs.h
+++ b/QtProject/app/prefs.h
@@ -15,11 +15,6 @@ public:
     enum SortCriterion { BySizeDescending, ByNameAscending, ByCreationDateAscending };
     static constexpr double DEFAULT_SSIM_THRESHOLD = 1.0;
     static constexpr int DEFAULT_MATCH_SIMILARITY_THRESHOLD = 100; // used for slider, as in % similarity
-    enum USE_CACHE_OPTION : int {
-        NO_CACHE,
-        WITH_CACHE,
-        CACHE_ONLY
-    };
 
     QWidget *_mainwPtr = nullptr;               //pointer to MainWindow, for connecting signals to it's slots
 
@@ -63,6 +58,50 @@ public:
 
     QString appVersion = "undefined";
 
+    // Error video modes: just leave as is (skip) or move to selected folder (move)
+    enum ErrorVideoModes { SKIP_ERROR_VIDEOS, MOVE_ERROR_VIDEOS };
+
+    ErrorVideoModes errorVideoMode() const {
+        if(this->errorVideoModeStatic == nullptr){
+            auto readOk = false;
+            auto mode = static_cast<ErrorVideoModes>(QSettings(APP_NAME, APP_NAME).value("error_video_mode").toInt(&readOk));
+            if(!readOk)
+                mode = SKIP_ERROR_VIDEOS;
+            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
+        }
+        return *this->errorVideoModeStatic;
+    }
+    void errorVideoMode(const ErrorVideoModes mode) {
+        if(this->errorVideoModeStatic == nullptr)
+            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
+        else
+            *this->errorVideoModeStatic = mode;
+        QSettings(APP_NAME, APP_NAME).setValue("error_video_mode", mode);
+    }
+
+    QDir errorVideosFolder() const {
+        if(this->errorVideosFolderStatic == nullptr){
+            const auto path = QSettings(APP_NAME, APP_NAME).value("error_videos_folder").toString();
+            auto dir = path.isEmpty() ? QDir::root() : QDir(path);
+            this->errorVideosFolderStatic = std::make_unique<QDir>(dir);
+        }
+        return *this->errorVideosFolderStatic;
+    }
+    void errorVideosFolder(const QDir dir) {
+        if(this->errorVideosFolderStatic == nullptr)
+            this->errorVideosFolderStatic = std::make_unique<QDir>(dir);
+        else
+            *this->errorVideosFolderStatic = dir;
+        QSettings(APP_NAME, APP_NAME).setValue("error_videos_folder", dir.absolutePath());
+    }
+
+    // Cache options: no cache, with cache, or cache only
+    enum USE_CACHE_OPTION : int {
+        NO_CACHE,
+        WITH_CACHE,
+        CACHE_ONLY
+    };
+
     USE_CACHE_OPTION useCacheOption() const {
         if(this->useCacheOptionStatic == nullptr){
             auto readOk = false;
@@ -97,6 +136,7 @@ public:
         QSettings(APP_NAME, APP_NAME).setValue("cache_file_path_name", cacheFilePathName);
     }
 
+    // Other small settings
     QString browseApplePhotosLastPath() const {return QSettings(APP_NAME, APP_NAME).value("browse_apple_photos_last_path").toString();}
     void browseApplePhotosLastPath(const QString dirPath) {QSettings(APP_NAME, APP_NAME).setValue("browse_apple_photos_last_path", dirPath);}
 
@@ -175,6 +215,8 @@ public:
         this->useCacheOptionStatic = nullptr;
         this->verboseStatic = nullptr;
         this->sortCriterionStatic = nullptr;
+        this->errorVideoModeStatic = nullptr;
+        this->errorVideosFolderStatic = nullptr;
         QSettings(APP_NAME, APP_NAME).clear();
     }
 private:
@@ -184,6 +226,8 @@ private:
     inline static std::unique_ptr<USE_CACHE_OPTION> useCacheOptionStatic = nullptr;
     inline static std::unique_ptr<bool> verboseStatic = nullptr;
     inline static std::unique_ptr<SortCriterion> sortCriterionStatic = nullptr;
+    inline static std::unique_ptr<ErrorVideoModes> errorVideoModeStatic = nullptr;
+    inline static std::unique_ptr<QDir> errorVideosFolderStatic = nullptr;
 };
 
 class Message: public QObject {

--- a/QtProject/app/prefs.h
+++ b/QtProject/app/prefs.h
@@ -55,15 +55,60 @@ public:
     int _sameDurationModifier = 1;
 
     DeletionModes delMode = STANDARD_TRASH;
-    QDir trashDir = QDir::root();
 
     QString appVersion = "undefined";
+
+    bool hasCustomTrashFolder() const {
+        if(this->customTrashFolderConfiguredStatic == nullptr){
+            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(QSettings(APP_NAME, APP_NAME).contains("custom_trash_folder"));
+        }
+        return *this->customTrashFolderConfiguredStatic;
+    }
+    // Only call this after ensuring hasCustomTrashFolder() is true
+    QDir customTrashFolder() const {
+        if(this->customTrashFolderStatic == nullptr){
+            auto settings = QSettings(APP_NAME, APP_NAME);
+            auto dir = QDir();
+            if(hasCustomTrashFolder()) {
+                dir = QDir(settings.value("custom_trash_folder").toString());
+            } else {
+                // This should not happen,
+                const auto standardVideosFolders = QStandardPaths::standardLocations(QStandardPaths::MoviesLocation);
+                dir = QDir(standardVideosFolders.isEmpty() ? QDir::homePath() : standardVideosFolders.first());
+            }
+            this->customTrashFolderStatic = std::make_unique<QDir>(dir);
+        }
+        return *this->customTrashFolderStatic;
+    }
+    void customTrashFolder(const QDir dir) {
+        if(this->customTrashFolderStatic == nullptr)
+            this->customTrashFolderStatic = std::make_unique<QDir>(dir);
+        else
+            *this->customTrashFolderStatic = dir;
+        if(this->customTrashFolderConfiguredStatic == nullptr)
+            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(true);
+        else
+            *this->customTrashFolderConfiguredStatic = true;
+        QSettings(APP_NAME, APP_NAME).setValue("custom_trash_folder", dir.absolutePath());
+    }
+    void clearCustomTrashFolder() {
+        this->customTrashFolderStatic = nullptr;
+        if(this->customTrashFolderConfiguredStatic == nullptr)
+            this->customTrashFolderConfiguredStatic = std::make_unique<bool>(false);
+        else
+            *this->customTrashFolderConfiguredStatic = false;
+        QSettings(APP_NAME, APP_NAME).remove("custom_trash_folder");
+    }
 
     // Error video modes: just leave as is (skip) or move to selected folder (move)
     enum ErrorVideoModes { SKIP_ERROR_VIDEOS, MOVE_ERROR_VIDEOS };
 
     ErrorVideoModes errorVideoMode() const {
-        return QSettings(APP_NAME, APP_NAME).contains("error_videos_folder") ? MOVE_ERROR_VIDEOS : SKIP_ERROR_VIDEOS;
+        if(this->errorVideoModeStatic == nullptr){
+            const auto mode = QSettings(APP_NAME, APP_NAME).contains("error_videos_folder") ? MOVE_ERROR_VIDEOS : SKIP_ERROR_VIDEOS;
+            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(mode);
+        }
+        return *this->errorVideoModeStatic;
     }
 
     // Only call this after ensuring errorVideoMode() is set to MOVE_ERROR_VIDEOS
@@ -72,7 +117,7 @@ public:
         if(this->errorVideosFolderStatic == nullptr){
             auto settings = QSettings(APP_NAME, APP_NAME);
             auto dir = QDir();
-            if(settings.contains("error_videos_folder")) {
+            if(errorVideoMode() == MOVE_ERROR_VIDEOS) {
                 dir = QDir(settings.value("error_videos_folder").toString());
             } else {
                 // This should never happen, and is actually invalid state
@@ -88,10 +133,18 @@ public:
             this->errorVideosFolderStatic = std::make_unique<QDir>(dir);
         else
             *this->errorVideosFolderStatic = dir;
+        if(this->errorVideoModeStatic == nullptr)
+            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(MOVE_ERROR_VIDEOS);
+        else
+            *this->errorVideoModeStatic = MOVE_ERROR_VIDEOS;
         QSettings(APP_NAME, APP_NAME).setValue("error_videos_folder", dir.absolutePath());
     }
     void clearErrorVideosFolder() {
         this->errorVideosFolderStatic = nullptr;
+        if(this->errorVideoModeStatic == nullptr)
+            this->errorVideoModeStatic = std::make_unique<ErrorVideoModes>(SKIP_ERROR_VIDEOS);
+        else
+            *this->errorVideoModeStatic = SKIP_ERROR_VIDEOS;
         QSettings(APP_NAME, APP_NAME).remove("error_videos_folder");
     }
 
@@ -215,16 +268,26 @@ public:
         this->useCacheOptionStatic = nullptr;
         this->verboseStatic = nullptr;
         this->sortCriterionStatic = nullptr;
+        this->customTrashFolderConfiguredStatic = nullptr;
+        this->customTrashFolderStatic = nullptr;
+        this->errorVideoModeStatic = nullptr;
         this->errorVideosFolderStatic = nullptr;
         QSettings(APP_NAME, APP_NAME).clear();
     }
 private:
+    // QSettings operations are quite slow, so we cache the values in memory
     inline static std::unique_ptr<int> thumbMode = nullptr;
     inline static std::unique_ptr<VisualComparisonModes> compMode = nullptr;
     inline static std::unique_ptr<QString> cacheFilePathNameStatic = nullptr;
     inline static std::unique_ptr<USE_CACHE_OPTION> useCacheOptionStatic = nullptr;
     inline static std::unique_ptr<bool> verboseStatic = nullptr;
     inline static std::unique_ptr<SortCriterion> sortCriterionStatic = nullptr;
+    // To know wether the custom trash folder setting was loaded from QSettings we need an extra flag
+    // because a QDir has no good state of "initialized but no value", it would just be root directory
+    inline static std::unique_ptr<bool> customTrashFolderConfiguredStatic = nullptr;
+    inline static std::unique_ptr<QDir> customTrashFolderStatic = nullptr;
+    // Similar for error video folder: we need an extra flag to differenciate between not loaded vs loaded from QSettings
+    inline static std::unique_ptr<ErrorVideoModes> errorVideoModeStatic = nullptr;
     inline static std::unique_ptr<QDir> errorVideosFolderStatic = nullptr;
 };
 


### PR DESCRIPTION
## Context
Closes #46.

Error videos are currently skipped and left untouched during scans. This adds an optional quarantine-style workflow so users can move files that fail processing into a chosen folder for later review or deletion.

## Changes summary
- Adds persisted error-video handling settings for either simple skip or move-to-folder behavior.
- Adds Tools menu actions to select the error video folder or restore the default skip behavior.
- Moves scan-time processing failures to the configured folder, using `-1` through `-100` filename suffixes to avoid collisions, while leaving Apple Photos Library paths untouched.

## Test plan
- [x] `git diff --check`
- [x] `cmake -S QtProject -B build -DCMAKE_BUILD_TYPE=Debug`
- [x] `cmake --build build --target CMakeFiles/video-simili-duplicate-cleaner.dir/app/mainwindow.cpp.o`
- [ ] Full app build was not completed locally because `QtProject/libraries/macos/opencv-arm/opencv-install/lib/libopencv_imgproc.a` is missing in this checkout.

Made with [Cursor](https://cursor.com)