### PR TITLE
chore(ci): rename local tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Local Tests
+name: Test
 
 on:
   pull_request:
@@ -8,11 +8,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: local-tests-${{ github.workflow }}-${{ github.ref }}
+  group: test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  linux-local-tests:
+  linux-test:
     name: Linux tiny repo-local tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -25,9 +25,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .apt-cache/archives
-          key: apt-linux-local-tests-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/local-tests.yml') }}
+          key: apt-linux-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/test.yml') }}
           restore-keys: |
-            apt-linux-local-tests-${{ runner.os }}-${{ runner.arch }}-
+            apt-linux-test-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install dependencies
         run: |
@@ -50,19 +50,19 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -S QtProject -B QtProject/builds/ci-local-tests -G Ninja \
+          cmake -S QtProject -B QtProject/builds/ci-test -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug
 
       - name: Build self-contained test targets
         run: |
-          cmake --build QtProject/builds/ci-local-tests --target \
+          cmake --build QtProject/builds/ci-test --target \
             test_comparison \
             test_mainwindow \
             test_auto_delete
 
       - name: Run self-contained tests
         run: |
-          ctest --test-dir QtProject/builds/ci-local-tests \
+          ctest --test-dir QtProject/builds/ci-test \
             --output-on-failure \
             -R "^(test_comparison|test_mainwindow|test_auto_delete)$"
 
@@ -118,7 +118,7 @@ jobs:
           path: macos-static-deps.tar.gz
           retention-days: 1
 
-  macos-local-tests:
+  macos-test:
     name: macOS local-like tests (${{ matrix.name }})
     needs: macos-static-deps
     runs-on: ${{ matrix.runner }}
@@ -158,20 +158,20 @@ jobs:
 
       - name: Configure
         run: |
-          cmake -S QtProject -B QtProject/builds/ci-macos-local-tests -G Ninja \
+          cmake -S QtProject -B QtProject/builds/ci-macos-test -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_PREFIX_PATH="$PWD/QtProject/libraries/macos/qt/qt-install" \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
 
       - name: Build self-contained test targets
         run: |
-          cmake --build QtProject/builds/ci-macos-local-tests --target \
+          cmake --build QtProject/builds/ci-macos-test --target \
             test_comparison \
             test_mainwindow \
             test_auto_delete
 
       - name: Run self-contained tests
         run: |
-          ctest --test-dir QtProject/builds/ci-macos-local-tests \
+          ctest --test-dir QtProject/builds/ci-macos-test \
             --output-on-failure \
             -R "^(test_comparison|test_mainwindow|test_auto_delete)$"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   linux-test:
-    name: Linux tiny repo-local tests
+    name: Linux tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -119,7 +119,7 @@ jobs:
           retention-days: 1
 
   macos-test:
-    name: macOS local-like tests (${{ matrix.name }})
+    name: macOS tests (${{ matrix.name }})
     needs: macos-static-deps
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15

--- a/QtProject/libraries/macos/qt/qt.sh
+++ b/QtProject/libraries/macos/qt/qt.sh
@@ -35,7 +35,7 @@ rm -rf "$BUILD_DIR" "$INSTALL_DIR" "$SOURCE_DIR"
 git clone "$QT_REPO_URL" --branch "$QT_VERSION" --depth 1 "$SOURCE_DIR"
 
 # Pull qtbase before configure so we can patch it when runner SDKs need it.
-perl "$SOURCE_DIR/init-repository" --module-subset="$QT_SUBMODULES"
+(cd "$SOURCE_DIR" && perl init-repository --module-subset="$QT_SUBMODULES")
 
 # Qt 6.9.3 predates QTBUG-145239: Xcode 26.4 reports __yield as a builtin
 # while still requiring <arm_acle.h>, so prefer Clang's arm yield intrinsic.

--- a/QtProject/libraries/macos/qt/qt.sh
+++ b/QtProject/libraries/macos/qt/qt.sh
@@ -19,8 +19,8 @@ QT_VERSION="$(npm --prefix "$PROJECT_ROOT" pkg get cpp-dependencies-macos.qt.ver
 
 echo "[qt.sh] Building Qt $QT_VERSION from $QT_REPO_URL"
 
-# Prerequisites (QtBase/Widgets/Sql/Concurrent do not need Python; configure
-# uses init-repository under the hood when -init-submodules is set, which needs perl)
+# Prerequisites (QtBase/Widgets/Sql/Concurrent do not need Python; Qt's
+# init-repository needs perl)
 for tool in cmake git ninja; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "[qt.sh] Error: $tool is required. Install it (e.g. brew install $tool)." >&2
@@ -33,6 +33,9 @@ rm -rf "$BUILD_DIR" "$INSTALL_DIR" "$SOURCE_DIR"
 
 # Clone Qt
 git clone "$QT_REPO_URL" --branch "$QT_VERSION" --depth 1 "$SOURCE_DIR"
+
+# Pull qtbase before configure so we can patch it when runner SDKs need it.
+perl "$SOURCE_DIR/init-repository" --module-subset="$QT_SUBMODULES"
 
 # Qt 6.9.3 predates QTBUG-145239: Xcode 26.4 reports __yield as a builtin
 # while still requiring <arm_acle.h>, so prefer Clang's arm yield intrinsic.
@@ -61,8 +64,6 @@ perl -0e '
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 "../$SOURCE_DIR/configure" \
-  -init-submodules \
-  -submodules "$QT_SUBMODULES" \
   -prefix "$SCRIPT_DIR/$INSTALL_DIR" \
   -release -static -no-framework \
   -nomake examples -nomake tests \

--- a/QtProject/libraries/macos/qt/qt.sh
+++ b/QtProject/libraries/macos/qt/qt.sh
@@ -34,6 +34,29 @@ rm -rf "$BUILD_DIR" "$INSTALL_DIR" "$SOURCE_DIR"
 # Clone Qt
 git clone "$QT_REPO_URL" --branch "$QT_VERSION" --depth 1 "$SOURCE_DIR"
 
+# Qt 6.9.3 predates QTBUG-145239: Xcode 26.4 reports __yield as a builtin
+# while still requiring <arm_acle.h>, so prefer Clang's arm yield intrinsic.
+QYIELDCPU_HEADER="$SOURCE_DIR/qtbase/src/corelib/thread/qyieldcpu.h"
+perl -0e '
+  use strict;
+  use warnings;
+
+  my ($path) = @ARGV;
+  open my $fh, "<", $path or die "[qt.sh] Cannot read $path: $!\n";
+  my $content = do { local $/; <$fh> };
+  close $fh;
+
+  my $generic_yield = "#if __has_builtin(__yield)\n    __yield();              // Generic\n";
+  my $arm_yield = "\n#elif __has_builtin(__builtin_arm_yield)\n    __builtin_arm_yield();\n";
+  $content =~ s/\Q$generic_yield\E/#if __has_builtin(__builtin_arm_yield)\n    __builtin_arm_yield();\n#elif __has_builtin(__yield)\n    __yield();              \/\/ Generic\n/
+    or die "[qt.sh] Could not apply qyieldcpu generic yield patch\n";
+  $content =~ s/\Q$arm_yield\E/\n/
+    or die "[qt.sh] Could not remove duplicate qyieldcpu arm yield branch\n";
+
+  open $fh, ">", $path or die "[qt.sh] Cannot write $path: $!\n";
+  print {$fh} $content;
+' "$QYIELDCPU_HEADER"
+
 # Configure via Qt's configure wrapper (documented path)
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"


### PR DESCRIPTION
## Context
The local test workflow has become the main repository test workflow, so the previous `local-tests` naming was more specific than the current purpose.

While validating the rename on a fresh PR branch, the macOS static dependency cache missed. That exposed a Qt 6.9.3 rebuild failure on the current macOS 26.4/Xcode runner: Qt's `qyieldcpu.h` checks `__yield` before `__builtin_arm_yield`, but the newer compiler requires `<arm_acle.h>` for `__yield`. The build script now applies the upstream-style ordering fix before configuring Qt.

## Changes summary
- Rename the GitHub Actions workflow file from `local-tests.yml` to `test.yml`.
- Update workflow, job, cache key, build directory, and check display names to match the shorter test workflow naming.
- Patch the macOS Qt dependency build so fresh cache misses can rebuild Qt on macOS 26.4 runners.

## Test plan
- `bash -n QtProject/libraries/macos/qt/qt.sh`
- GitHub Actions PR workflow rerun.