### PR TITLE
ci: add Windows MSIX packaging workflow

### DIFF
--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -66,7 +66,9 @@ jobs:
       - name: Install vcpkg
         shell: pwsh
         run: |
-          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
+          # Keep the port history local so manifest resolution does not depend on
+          # a later promisor fetch while the build is already running.
+          git clone --no-filter https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Verify Visual Studio toolchains

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -120,19 +120,6 @@ jobs:
           BUILD_SCRIPT: ${{ matrix.build-script }}
         run: npm run $env:BUILD_SCRIPT
 
-      - name: Collect MSIX for bundle
-        shell: pwsh
-        env:
-          MSIX_NAME: ${{ matrix.artifact }}
-        run: |
-          $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
-          if (-not (Test-Path $msix)) {
-            throw "Expected package was not produced: $msix"
-          }
-
-          New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\bundle-input" -Force | Out-Null
-          Copy-Item $msix "$env:RUNNER_TEMP\bundle-input\$env:MSIX_NAME"
-
       - name: Collect MSIX
         shell: pwsh
         env:
@@ -143,7 +130,9 @@ jobs:
             throw "Expected package was not produced: $msix"
           }
 
+          New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\bundle-input" -Force | Out-Null
           New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\package" -Force | Out-Null
+          Copy-Item $msix "$env:RUNNER_TEMP\bundle-input\$env:MSIX_NAME"
           Copy-Item $msix "$env:RUNNER_TEMP\package\$env:MSIX_NAME"
 
       - name: Collect matching VCLibs framework package

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,0 +1,156 @@
+name: Windows package
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-package.yml"
+      - "QtProject/**"
+      - "package-lock.json"
+      - "package.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-package-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: Package ${{ matrix.architecture }}
+    # The stable VS2022 image can cross-build ARM64 and build x64 without
+    # depending on the public-preview Windows ARM runner.
+    runs-on: windows-2022
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: arm64
+            build-script: win-build-arm64
+            artifact: Video simili duplicate cleaner.arm64.msix
+          - architecture: x64
+            build-script: win-build-x64
+            artifact: Video simili duplicate cleaner.x64.msix
+    env:
+      VCPKG_ROOT: ${{ runner.temp }}\vcpkg
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-binary-cache
+      VCPKG_DISABLE_METRICS: 1
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install JavaScript dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\vcpkg-binary-cache
+          key: windows-vcpkg-${{ matrix.architecture }}-${{ hashFiles('QtProject/vcpkg.json') }}
+          restore-keys: |
+            windows-vcpkg-${{ matrix.architecture }}-
+
+      - name: Install vcpkg at the manifest baseline
+        shell: pwsh
+        run: |
+          git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
+          git -C "$env:VCPKG_ROOT" checkout 96fd599859beaed2ae891a2b2982746f28611b07
+          & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
+
+      - name: Verify Visual Studio toolchains
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe was not found on the Windows runner"
+          }
+
+          $installationPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          if (-not $installationPath) {
+            throw "The Visual Studio ARM64 C++ toolchain is not installed"
+          }
+
+          Write-Host "Using Visual Studio at $installationPath"
+
+          $makeAppx = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter MakeAppx.exe -Recurse |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $makeAppx) {
+            throw "MakeAppx.exe was not found on the Windows runner"
+          }
+
+          $makeAppx.Directory.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build MSIX
+        shell: pwsh
+        env:
+          BUILD_SCRIPT: ${{ matrix.build-script }}
+        run: npm run $env:BUILD_SCRIPT
+
+      - name: Collect MSIX
+        shell: pwsh
+        env:
+          MSIX_NAME: ${{ matrix.artifact }}
+        run: |
+          $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
+          if (-not (Test-Path $msix)) {
+            throw "Expected package was not produced: $msix"
+          }
+
+          New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\package" -Force | Out-Null
+          Copy-Item $msix "$env:RUNNER_TEMP\package\$env:MSIX_NAME"
+
+      - name: Upload MSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msix-${{ matrix.architecture }}
+          path: ${{ runner.temp }}\package\${{ matrix.artifact }}
+          if-no-files-found: error
+          retention-days: 7
+
+  bundle:
+    name: Bundle MSIX packages
+    needs: package
+    runs-on: windows-2022
+    timeout-minutes: 15
+
+    steps:
+      - name: Download MSIX packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: windows-msix-*
+          merge-multiple: true
+          path: ${{ runner.temp }}\bundle
+
+      - name: Create MSIX bundle
+        shell: pwsh
+        run: |
+          $makeAppx = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter MakeAppx.exe -Recurse |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $makeAppx) {
+            throw "MakeAppx.exe was not found on the Windows runner"
+          }
+
+          $bundle = Join-Path $env:GITHUB_WORKSPACE "Video simili duplicate cleaner.msixbundle"
+          & $makeAppx.FullName bundle /d "$env:RUNNER_TEMP\bundle" /p $bundle
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path $bundle)) {
+            throw "MakeAppx failed to create the bundle"
+          }
+
+      - name: Upload MSIX bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msixbundle
+          path: Video simili duplicate cleaner.msixbundle
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -127,7 +127,8 @@ jobs:
           name: windows-msix-${{ matrix.architecture }}
           path: ${{ runner.temp }}\package\${{ matrix.artifact }}
           if-no-files-found: error
-          retention-days: 1
+          # Keep the package available long enough to download and submit it.
+          retention-days: 2
 
   bundle:
     name: Bundle MSIX packages
@@ -166,4 +167,4 @@ jobs:
           name: windows-msixbundle
           path: Video simili duplicate cleaner.msixbundle
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 2

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,12 +1,6 @@
 name: Windows package
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/windows-package.yml"
-      - "QtProject/**"
-      - "package-lock.json"
-      - "package.json"
   workflow_dispatch:
 
 permissions:
@@ -133,7 +127,7 @@ jobs:
           name: windows-msix-${{ matrix.architecture }}
           path: ${{ runner.temp }}\package\${{ matrix.artifact }}
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
 
   bundle:
     name: Bundle MSIX packages
@@ -172,4 +166,4 @@ jobs:
           name: windows-msixbundle
           path: Video simili duplicate cleaner.msixbundle
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -73,6 +73,9 @@ jobs:
           # Keep the port history local so manifest resolution does not depend on
           # a later promisor fetch while the build is already running.
           git clone --no-filter https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
+          # This commit has the manifest's Qt/FFmpeg versions and the NASM
+          # version supported by the current AOM port.
+          git -C "$env:VCPKG_ROOT" checkout 12ae26a216f4c922a8189ed5c691bdb3f8bab686
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Verify Visual Studio toolchains

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -180,6 +180,24 @@ jobs:
           New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\package" -Force | Out-Null
           Copy-Item $msix "$env:RUNNER_TEMP\package\$env:MSIX_NAME"
 
+      - name: Collect matching VCLibs framework package
+        shell: pwsh
+        env:
+          TARGET_ARCHITECTURE: ${{ matrix.architecture }}
+        run: |
+          $vclibsRoot = Join-Path ${env:ProgramFiles(x86)} "Microsoft SDKs\Windows Kits\10\ExtensionSDKs\Microsoft.VCLibs.Desktop\14.0\Appx\Retail"
+          $vclibs = Get-ChildItem $vclibsRoot -Recurse -Filter "Microsoft.VCLibs.*.14.00.Desktop.appx" |
+            Where-Object { $_.Directory.Name -eq $env:TARGET_ARCHITECTURE } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $vclibs) {
+            throw "Matching VCLibs framework package was not found for $env:TARGET_ARCHITECTURE under $vclibsRoot"
+          }
+
+          New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\vclibs" -Force | Out-Null
+          Copy-Item $vclibs.FullName "$env:RUNNER_TEMP\vclibs\$($vclibs.Name)"
+          Write-Host "Collected $($vclibs.Name)"
+
       - name: Upload MSIX
         uses: actions/upload-artifact@v4
         with:
@@ -187,6 +205,14 @@ jobs:
           path: ${{ runner.temp }}\package\${{ matrix.artifact }}
           if-no-files-found: error
           # Keep the package available long enough to download and submit it.
+          retention-days: 2
+
+      - name: Upload VCLibs dependency
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-vclibs-${{ matrix.architecture }}
+          path: ${{ runner.temp }}\vclibs\*.appx
+          if-no-files-found: error
           retention-days: 2
 
   bundle:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -29,7 +29,9 @@ jobs:
         include:
           - architecture: arm64
             build-script: win-build-arm64
-            makeappx_architecture: arm64
+            # MakeAppx is a host tool; the x64 executable can package ARM64
+            # contents and is the one that runs on this x64 Windows runner.
+            makeappx_architecture: x64
             artifact: Video simili duplicate cleaner.arm64.msix
           - architecture: x64
             build-script: win-build-x64

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -55,6 +55,10 @@ jobs:
           "VCPKG_ROOT=$env:RUNNER_TEMP\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "VCPKG_DEFAULT_BINARY_CACHE=$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Prepare vcpkg binary cache
+        shell: pwsh
+        run: New-Item -ItemType Directory -Path $env:VCPKG_DEFAULT_BINARY_CACHE -Force | Out-Null
+
       - name: Restore vcpkg binary cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -1,13 +1,8 @@
 name: Windows package
 
+# CI publishes unsigned packages; local disposable-VM instructions handle test signing.
 on:
   workflow_dispatch:
-    inputs:
-      sign_for_testing:
-        description: Sign the MSIX packages and bundle for installation in the test VM
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -125,7 +120,7 @@ jobs:
           BUILD_SCRIPT: ${{ matrix.build-script }}
         run: npm run $env:BUILD_SCRIPT
 
-      - name: Collect unsigned MSIX for bundle
+      - name: Collect MSIX for bundle
         shell: pwsh
         env:
           MSIX_NAME: ${{ matrix.artifact }}
@@ -137,63 +132,6 @@ jobs:
 
           New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\bundle-input" -Force | Out-Null
           Copy-Item $msix "$env:RUNNER_TEMP\bundle-input\$env:MSIX_NAME"
-
-      - name: Prepare test-signing certificate
-        if: ${{ inputs.sign_for_testing == true }}
-        shell: pwsh
-        env:
-          SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_BASE64 }}
-          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_BASE64)) {
-            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not configured"
-          }
-          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_PASSWORD)) {
-            throw "WINDOWS_MSIX_SIGNING_PFX_PASSWORD is not configured"
-          }
-
-          $pfx = Join-Path $env:RUNNER_TEMP "video-simili-msix-signing.pfx"
-          try {
-            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:SIGNING_PFX_BASE64))
-          } catch {
-            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not valid base64: $($_.Exception.Message)"
-          }
-
-          $securePassword = ConvertTo-SecureString $env:SIGNING_PFX_PASSWORD -AsPlainText -Force
-          $certificate = Get-PfxCertificate -FilePath $pfx -Password $securePassword
-          if ($certificate.Subject -ne "CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB") {
-            throw "The signing certificate subject does not match the package publisher: $($certificate.Subject)"
-          }
-          if ($certificate.NotAfter -le [DateTime]::Now) {
-            throw "The signing certificate is expired: $($certificate.NotAfter.ToString('u'))"
-          }
-
-          "SIGNING_PFX=$pfx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Sign MSIX for test installation
-        if: ${{ inputs.sign_for_testing == true }}
-        shell: pwsh
-        env:
-          MSIX_NAME: ${{ matrix.artifact }}
-          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
-        run: |
-          $signTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter SignTool.exe -Recurse |
-            Where-Object { $_.Directory.Name -eq $env:MAKEAPPX_ARCHITECTURE } |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
-          if (-not $signTool) {
-            throw "SignTool.exe was not found on the Windows runner"
-          }
-
-          $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
-          try {
-            & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $msix
-            if ($LASTEXITCODE -ne 0) {
-              throw "SignTool failed to sign $msix"
-            }
-          } finally {
-            Remove-Item -LiteralPath $env:SIGNING_PFX -Force -ErrorAction SilentlyContinue
-          }
 
       - name: Collect MSIX
         shell: pwsh
@@ -235,7 +173,7 @@ jobs:
           # Keep the package available long enough to download and submit it.
           retention-days: 2
 
-      - name: Upload unsigned MSIX for bundle
+      - name: Upload MSIX for bundle
         uses: actions/upload-artifact@v4
         with:
           name: windows-msix-bundle-input-${{ matrix.architecture }}
@@ -280,60 +218,6 @@ jobs:
           & $makeAppx.FullName bundle /d "$env:RUNNER_TEMP\bundle" /p $bundle
           if ($LASTEXITCODE -ne 0 -or -not (Test-Path $bundle)) {
             throw "MakeAppx failed to create the bundle"
-          }
-
-      - name: Prepare test-signing certificate
-        if: ${{ inputs.sign_for_testing == true }}
-        shell: pwsh
-        env:
-          SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_BASE64 }}
-          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_BASE64) -or
-              [string]::IsNullOrWhiteSpace($env:SIGNING_PFX_PASSWORD)) {
-            throw "Windows MSIX signing secrets are not configured"
-          }
-
-          $pfx = Join-Path $env:RUNNER_TEMP "video-simili-msix-signing.pfx"
-          try {
-            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:SIGNING_PFX_BASE64))
-          } catch {
-            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not valid base64: $($_.Exception.Message)"
-          }
-
-          $securePassword = ConvertTo-SecureString $env:SIGNING_PFX_PASSWORD -AsPlainText -Force
-          $certificate = Get-PfxCertificate -FilePath $pfx -Password $securePassword
-          if ($certificate.Subject -ne "CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB") {
-            throw "The signing certificate subject does not match the package publisher: $($certificate.Subject)"
-          }
-          if ($certificate.NotAfter -le [DateTime]::Now) {
-            throw "The signing certificate is expired: $($certificate.NotAfter.ToString('u'))"
-          }
-
-          "SIGNING_PFX=$pfx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Sign MSIX bundle for test installation
-        if: ${{ inputs.sign_for_testing == true }}
-        shell: pwsh
-        env:
-          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
-        run: |
-          $signTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter SignTool.exe -Recurse |
-            Where-Object { $_.Directory.Name -eq "x64" } |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
-          if (-not $signTool) {
-            throw "SignTool.exe was not found on the Windows runner"
-          }
-
-          $bundle = Join-Path $env:GITHUB_WORKSPACE "Video simili duplicate cleaner.msixbundle"
-          try {
-            & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $bundle
-            if ($LASTEXITCODE -ne 0) {
-              throw "SignTool failed to sign $bundle"
-            }
-          } finally {
-            Remove-Item -LiteralPath $env:SIGNING_PFX -Force -ErrorAction SilentlyContinue
           }
 
       - name: Upload MSIX bundle

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -63,11 +63,10 @@ jobs:
           restore-keys: |
             windows-vcpkg-${{ matrix.architecture }}-
 
-      - name: Install vcpkg at the manifest baseline
+      - name: Install vcpkg
         shell: pwsh
         run: |
           git clone --filter=blob:none https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
-          git -C "$env:VCPKG_ROOT" checkout 96fd599859beaed2ae891a2b2982746f28611b07
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Verify Visual Studio toolchains

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -29,12 +29,15 @@ jobs:
         include:
           - architecture: arm64
             build-script: win-build-arm64
+            makeappx_architecture: arm64
             artifact: Video simili duplicate cleaner.arm64.msix
           - architecture: x64
             build-script: win-build-x64
+            makeappx_architecture: x64
             artifact: Video simili duplicate cleaner.x64.msix
     env:
       VCPKG_DISABLE_METRICS: 1
+      MAKEAPPX_ARCHITECTURE: ${{ matrix.makeappx_architecture }}
 
     steps:
       - name: Check out source
@@ -94,6 +97,7 @@ jobs:
           Write-Host "Using Visual Studio at $installationPath"
 
           $makeAppx = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter MakeAppx.exe -Recurse |
+            Where-Object { $_.Directory.Name -eq $env:MAKEAPPX_ARCHITECTURE } |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
           if (-not $makeAppx) {
@@ -147,6 +151,7 @@ jobs:
         shell: pwsh
         run: |
           $makeAppx = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter MakeAppx.exe -Recurse |
+            Where-Object { $_.Directory.Name -eq "x64" } |
             Sort-Object LastWriteTime -Descending |
             Select-Object -First 1
           if (-not $makeAppx) {

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       VCPKG_DISABLE_METRICS: 1
       MAKEAPPX_ARCHITECTURE: ${{ matrix.makeappx_architecture }}
+      VCPKG_COMMIT: 12ae26a216f4c922a8189ed5c691bdb3f8bab686
 
     steps:
       - name: Check out source
@@ -68,9 +69,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}\vcpkg-binary-cache
-          key: windows-vcpkg-${{ matrix.architecture }}-${{ hashFiles('QtProject/vcpkg.json') }}
+          # Keep the primary key independent of branch/ref. The restore prefix
+          # searches for any reachable cache for this architecture and vcpkg
+          # revision, while vcpkg's ABI keys separate incompatible builds.
+          key: windows-vcpkg-${{ matrix.architecture }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('QtProject/vcpkg.json', 'QtProject/CMakePresets.json', 'QtProject/vcpkg-triplets/**') }}
           restore-keys: |
-            windows-vcpkg-${{ matrix.architecture }}-
+            windows-vcpkg-${{ matrix.architecture }}-${{ env.VCPKG_COMMIT }}-
 
       - name: Install vcpkg
         shell: pwsh
@@ -80,20 +84,27 @@ jobs:
           git clone --no-filter https://github.com/microsoft/vcpkg.git "$env:VCPKG_ROOT"
           # This commit has the manifest's Qt/FFmpeg versions and the NASM
           # version supported by the current AOM port.
-          git -C "$env:VCPKG_ROOT" checkout 12ae26a216f4c922a8189ed5c691bdb3f8bab686
+          git -C "$env:VCPKG_ROOT" checkout $env:VCPKG_COMMIT
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Verify Visual Studio toolchains
         shell: pwsh
+        env:
+          TARGET_ARCHITECTURE: ${{ matrix.architecture }}
         run: |
           $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
           if (-not (Test-Path $vswhere)) {
             throw "vswhere.exe was not found on the Windows runner"
           }
 
-          $installationPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          $requiredComponent = if ($env:TARGET_ARCHITECTURE -eq "arm64") {
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+          } else {
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+          }
+          $installationPath = & $vswhere -latest -products * -requires $requiredComponent -property installationPath
           if (-not $installationPath) {
-            throw "The Visual Studio ARM64 C++ toolchain is not installed"
+            throw "The Visual Studio C++ toolchain for $env:TARGET_ARCHITECTURE is not installed"
           }
 
           Write-Host "Using Visual Studio at $installationPath"
@@ -113,6 +124,19 @@ jobs:
         env:
           BUILD_SCRIPT: ${{ matrix.build-script }}
         run: npm run $env:BUILD_SCRIPT
+
+      - name: Collect unsigned MSIX for bundle
+        shell: pwsh
+        env:
+          MSIX_NAME: ${{ matrix.artifact }}
+        run: |
+          $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
+          if (-not (Test-Path $msix)) {
+            throw "Expected package was not produced: $msix"
+          }
+
+          New-Item -ItemType Directory -Path "$env:RUNNER_TEMP\bundle-input" -Force | Out-Null
+          Copy-Item $msix "$env:RUNNER_TEMP\bundle-input\$env:MSIX_NAME"
 
       - name: Prepare test-signing certificate
         if: ${{ inputs.sign_for_testing == true }}
@@ -162,9 +186,13 @@ jobs:
           }
 
           $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
-          & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $msix
-          if ($LASTEXITCODE -ne 0) {
-            throw "SignTool failed to sign $msix"
+          try {
+            & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $msix
+            if ($LASTEXITCODE -ne 0) {
+              throw "SignTool failed to sign $msix"
+            }
+          } finally {
+            Remove-Item -LiteralPath $env:SIGNING_PFX -Force -ErrorAction SilentlyContinue
           }
 
       - name: Collect MSIX
@@ -207,6 +235,14 @@ jobs:
           # Keep the package available long enough to download and submit it.
           retention-days: 2
 
+      - name: Upload unsigned MSIX for bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msix-bundle-input-${{ matrix.architecture }}
+          path: ${{ runner.temp }}\bundle-input\${{ matrix.artifact }}
+          if-no-files-found: error
+          retention-days: 2
+
       - name: Upload VCLibs dependency
         uses: actions/upload-artifact@v4
         with:
@@ -225,7 +261,7 @@ jobs:
       - name: Download MSIX packages
         uses: actions/download-artifact@v4
         with:
-          pattern: windows-msix-*
+          pattern: windows-msix-bundle-input-*
           merge-multiple: true
           path: ${{ runner.temp }}\bundle
 
@@ -291,9 +327,13 @@ jobs:
           }
 
           $bundle = Join-Path $env:GITHUB_WORKSPACE "Video simili duplicate cleaner.msixbundle"
-          & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $bundle
-          if ($LASTEXITCODE -ne 0) {
-            throw "SignTool failed to sign $bundle"
+          try {
+            & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $bundle
+            if ($LASTEXITCODE -ne 0) {
+              throw "SignTool failed to sign $bundle"
+            }
+          } finally {
+            Remove-Item -LiteralPath $env:SIGNING_PFX -Force -ErrorAction SilentlyContinue
           }
 
       - name: Upload MSIX bundle

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -34,8 +34,6 @@ jobs:
             build-script: win-build-x64
             artifact: Video simili duplicate cleaner.x64.msix
     env:
-      VCPKG_ROOT: ${{ runner.temp }}\vcpkg
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ runner.temp }}\vcpkg-binary-cache
       VCPKG_DISABLE_METRICS: 1
 
     steps:
@@ -50,6 +48,12 @@ jobs:
 
       - name: Install JavaScript dependencies
         run: npm ci --ignore-scripts
+
+      - name: Set vcpkg paths
+        shell: pwsh
+        run: |
+          "VCPKG_ROOT=$env:RUNNER_TEMP\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "VCPKG_DEFAULT_BINARY_CACHE=$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Restore vcpkg binary cache
         uses: actions/cache@v4

--- a/.github/workflows/windows-package.yml
+++ b/.github/workflows/windows-package.yml
@@ -2,6 +2,12 @@ name: Windows package
 
 on:
   workflow_dispatch:
+    inputs:
+      sign_for_testing:
+        description: Sign the MSIX packages and bundle for installation in the test VM
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -108,6 +114,59 @@ jobs:
           BUILD_SCRIPT: ${{ matrix.build-script }}
         run: npm run $env:BUILD_SCRIPT
 
+      - name: Prepare test-signing certificate
+        if: ${{ inputs.sign_for_testing == true }}
+        shell: pwsh
+        env:
+          SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_BASE64 }}
+          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_BASE64)) {
+            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not configured"
+          }
+          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_PASSWORD)) {
+            throw "WINDOWS_MSIX_SIGNING_PFX_PASSWORD is not configured"
+          }
+
+          $pfx = Join-Path $env:RUNNER_TEMP "video-simili-msix-signing.pfx"
+          try {
+            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:SIGNING_PFX_BASE64))
+          } catch {
+            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not valid base64: $($_.Exception.Message)"
+          }
+
+          $securePassword = ConvertTo-SecureString $env:SIGNING_PFX_PASSWORD -AsPlainText -Force
+          $certificate = Get-PfxCertificate -FilePath $pfx -Password $securePassword
+          if ($certificate.Subject -ne "CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB") {
+            throw "The signing certificate subject does not match the package publisher: $($certificate.Subject)"
+          }
+          if ($certificate.NotAfter -le [DateTime]::Now) {
+            throw "The signing certificate is expired: $($certificate.NotAfter.ToString('u'))"
+          }
+
+          "SIGNING_PFX=$pfx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Sign MSIX for test installation
+        if: ${{ inputs.sign_for_testing == true }}
+        shell: pwsh
+        env:
+          MSIX_NAME: ${{ matrix.artifact }}
+          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
+        run: |
+          $signTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter SignTool.exe -Recurse |
+            Where-Object { $_.Directory.Name -eq $env:MAKEAPPX_ARCHITECTURE } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $signTool) {
+            throw "SignTool.exe was not found on the Windows runner"
+          }
+
+          $msix = Join-Path $env:GITHUB_WORKSPACE "QtProject\release-build\windows\$env:MSIX_NAME"
+          & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $msix
+          if ($LASTEXITCODE -ne 0) {
+            throw "SignTool failed to sign $msix"
+          }
+
       - name: Collect MSIX
         shell: pwsh
         env:
@@ -159,6 +218,56 @@ jobs:
           & $makeAppx.FullName bundle /d "$env:RUNNER_TEMP\bundle" /p $bundle
           if ($LASTEXITCODE -ne 0 -or -not (Test-Path $bundle)) {
             throw "MakeAppx failed to create the bundle"
+          }
+
+      - name: Prepare test-signing certificate
+        if: ${{ inputs.sign_for_testing == true }}
+        shell: pwsh
+        env:
+          SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_BASE64 }}
+          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:SIGNING_PFX_BASE64) -or
+              [string]::IsNullOrWhiteSpace($env:SIGNING_PFX_PASSWORD)) {
+            throw "Windows MSIX signing secrets are not configured"
+          }
+
+          $pfx = Join-Path $env:RUNNER_TEMP "video-simili-msix-signing.pfx"
+          try {
+            [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:SIGNING_PFX_BASE64))
+          } catch {
+            throw "WINDOWS_MSIX_SIGNING_PFX_BASE64 is not valid base64: $($_.Exception.Message)"
+          }
+
+          $securePassword = ConvertTo-SecureString $env:SIGNING_PFX_PASSWORD -AsPlainText -Force
+          $certificate = Get-PfxCertificate -FilePath $pfx -Password $securePassword
+          if ($certificate.Subject -ne "CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB") {
+            throw "The signing certificate subject does not match the package publisher: $($certificate.Subject)"
+          }
+          if ($certificate.NotAfter -le [DateTime]::Now) {
+            throw "The signing certificate is expired: $($certificate.NotAfter.ToString('u'))"
+          }
+
+          "SIGNING_PFX=$pfx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Sign MSIX bundle for test installation
+        if: ${{ inputs.sign_for_testing == true }}
+        shell: pwsh
+        env:
+          SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_MSIX_SIGNING_PFX_PASSWORD }}
+        run: |
+          $signTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter SignTool.exe -Recurse |
+            Where-Object { $_.Directory.Name -eq "x64" } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if (-not $signTool) {
+            throw "SignTool.exe was not found on the Windows runner"
+          }
+
+          $bundle = Join-Path $env:GITHUB_WORKSPACE "Video simili duplicate cleaner.msixbundle"
+          & $signTool.FullName sign /fd SHA256 /f $env:SIGNING_PFX /p $env:SIGNING_PFX_PASSWORD $bundle
+          if ($LASTEXITCODE -ne 0) {
+            throw "SignTool failed to sign $bundle"
           }
 
       - name: Upload MSIX bundle

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -52,32 +52,22 @@ SignTool sign /fd SHA256  /a /f C:\Dev\CertifVideoSimili.pfx /p <certificate pas
 
 See more info in https://docs.microsoft.com/fr-fr/windows/msix/package/sign-app-package-using-signtool
 
-### Sign test artifacts in CI
+### Test CI artifacts locally
 
-The `Windows package` GitHub Actions workflow keeps the Store submission path
-unsigned. To produce artifacts that can be installed in the disposable Windows
-test VM, run the workflow manually with `sign_for_testing` enabled.
+The `Windows package` GitHub Actions workflow intentionally publishes unsigned
+MSIX packages and an unsigned bundle. Use the local certificate and SignTool
+instructions above to sign downloaded test artifacts on the disposable VM path;
+do not put a PFX, password, or signing secret in GitHub Actions.
 
-The repository must have these Actions secrets configured; do not commit either
-the PFX or its password:
-
-- `WINDOWS_MSIX_SIGNING_PFX_BASE64`: base64 contents of a PFX containing the
-  private key.
-- `WINDOWS_MSIX_SIGNING_PFX_PASSWORD`: the PFX password.
-
-The certificate subject must remain exactly
-`CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB`, matching `appxmanifest.xml`. The
-workflow validates the subject and expiry, signs both architecture-specific
-MSIX packages and the final bundle, and uploads those signed test artifacts.
-The test VM must trust the corresponding public certificate before installing
-them. Keep `sign_for_testing` disabled for packages intended for Microsoft
-Store submission.
-
-For sideload testing, the workflow also uploads the architecture-matched
-`Microsoft.VCLibs.140.00.UWPDesktop` framework package as
+For sideload testing, download the architecture-matched
+`Microsoft.VCLibs.140.00.UWPDesktop` framework package from the workflow as
 `windows-vclibs-arm64` or `windows-vclibs-x64`. Install that `.appx` first in
-the disposable VM, then install the signed application bundle. The Store path
-is unchanged: the manifest dependency lets the Store provide VCLibs itself.
+the disposable VM, then sign and install the application bundle locally. The
+Store path is unchanged: the manifest dependency lets the Store provide
+VCLibs itself.
+
+Never upload a locally signed test artifact to the Microsoft Store; submit the
+unsigned CI bundle instead.
 
 ### Install the certificate to test install the app.
 Now import the certificate to the computer's trusted certificates, with "Manage computer certificates", go to Trusted People part, click on certificates, and "Action", "All Tasks", import -> then select the exported certificate file, and import it.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -73,11 +73,11 @@ The test VM must trust the corresponding public certificate before installing
 them. Keep `sign_for_testing` disabled for packages intended for Microsoft
 Store submission.
 
-The Windows CMake presets use the `arm64-windows-static` and
-`x64-windows-static` vcpkg triplets. This statically links the MSVC runtime
-into the packaged executable, avoiding a separate runtime installation on a
-clean Windows test image. The MSIX manifest still declares the Microsoft
-VCLibs framework dependency required by the Qt/C++ package.
+For sideload testing, the workflow also uploads the architecture-matched
+`Microsoft.VCLibs.140.00.UWPDesktop` framework package as
+`windows-vclibs-arm64` or `windows-vclibs-x64`. Install that `.appx` first in
+the disposable VM, then install the signed application bundle. The Store path
+is unchanged: the manifest dependency lets the Store provide VCLibs itself.
 
 ### Install the certificate to test install the app.
 Now import the certificate to the computer's trusted certificates, with "Manage computer certificates", go to Trusted People part, click on certificates, and "Action", "All Tasks", import -> then select the exported certificate file, and import it.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -52,6 +52,33 @@ SignTool sign /fd SHA256  /a /f C:\Dev\CertifVideoSimili.pfx /p <certificate pas
 
 See more info in https://docs.microsoft.com/fr-fr/windows/msix/package/sign-app-package-using-signtool
 
+### Sign test artifacts in CI
+
+The `Windows package` GitHub Actions workflow keeps the Store submission path
+unsigned. To produce artifacts that can be installed in the disposable Windows
+test VM, run the workflow manually with `sign_for_testing` enabled.
+
+The repository must have these Actions secrets configured; do not commit either
+the PFX or its password:
+
+- `WINDOWS_MSIX_SIGNING_PFX_BASE64`: base64 contents of a PFX containing the
+  private key.
+- `WINDOWS_MSIX_SIGNING_PFX_PASSWORD`: the PFX password.
+
+The certificate subject must remain exactly
+`CN=4718DAC3-F3E7-40DE-AF8E-C3EB08A4F6AB`, matching `appxmanifest.xml`. The
+workflow validates the subject and expiry, signs both architecture-specific
+MSIX packages and the final bundle, and uploads those signed test artifacts.
+The test VM must trust the corresponding public certificate before installing
+them. Keep `sign_for_testing` disabled for packages intended for Microsoft
+Store submission.
+
+The Windows CMake presets use the `arm64-windows-static` and
+`x64-windows-static` vcpkg triplets. This statically links the MSVC runtime
+into the packaged executable, avoiding a separate runtime installation on a
+clean Windows test image. The MSIX manifest still declares the Microsoft
+VCLibs framework dependency required by the Qt/C++ package.
+
 ### Install the certificate to test install the app.
 Now import the certificate to the computer's trusted certificates, with "Manage computer certificates", go to Trusted People part, click on certificates, and "Action", "All Tasks", import -> then select the exported certificate file, and import it.
 

--- a/QtProject/CMakePresets.json
+++ b/QtProject/CMakePresets.json
@@ -9,6 +9,7 @@
         {
             "name": "vcpkg-arm64-static",
             "generator": "Visual Studio 17 2022",
+            "architecture": "ARM64",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",

--- a/QtProject/CMakePresets.json
+++ b/QtProject/CMakePresets.json
@@ -13,7 +13,7 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md-opencv-neon",
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md-n",
                 "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
             }
         },

--- a/QtProject/CMakePresets.json
+++ b/QtProject/CMakePresets.json
@@ -13,7 +13,7 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "arm64-windows-static"
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md"
             }
         },
         {
@@ -23,7 +23,7 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
             }
         },
         {

--- a/QtProject/CMakePresets.json
+++ b/QtProject/CMakePresets.json
@@ -13,7 +13,8 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md"
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md-opencv-neon",
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
             }
         },
         {
@@ -23,7 +24,8 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static-md",
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets"
             }
         },
         {

--- a/QtProject/CMakePresets.json
+++ b/QtProject/CMakePresets.json
@@ -13,7 +13,7 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "arm64-windows-static-md"
+                "VCPKG_TARGET_TRIPLET": "arm64-windows-static"
             }
         },
         {
@@ -23,7 +23,7 @@
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static"
             }
         },
         {

--- a/QtProject/release-build/windows/package.json
+++ b/QtProject/release-build/windows/package.json
@@ -4,7 +4,7 @@
     "build-win-binaries-x64": "npm run cmake-configure-x64 && npm run cmake-build && npm run copy-exe && npm run prep-package-x64 && npm run package-app-x64",
     "cmake-configure-arm64": "cmake -S ..\\.. -B .\\build --preset vcpkg-arm64-static",
     "cmake-configure-x64": "cmake -S ..\\.. -B .\\build --preset vcpkg-x64-static",
-    "cmake-build": "cmake --build .\\build --config Release",
+    "cmake-build": "cmake --build .\\build --config Release --target video-simili-duplicate-cleaner",
     "copy-exe": "if not exist final mkdir final && copy .\\build\\Release\\video-simili-duplicate-cleaner.exe final\\\"Video simili duplicate cleaner.exe\"",
     "prep-package-arm64": "npm run icons && node process-manifest-template.js arm64 appxmanifest.template.xml final\\appxmanifest.xml",
     "prep-package-x64": "npm run icons && node process-manifest-template.js x64 appxmanifest.template.xml final\\appxmanifest.xml",

--- a/QtProject/vcpkg-triplets/arm64-windows-static-md-n.cmake
+++ b/QtProject/vcpkg-triplets/arm64-windows-static-md-n.cmake
@@ -2,6 +2,8 @@ set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
 
+# The short triplet name also keeps generated Windows linker paths below the
+# legacy MAX_PATH limit.
 # OpenCV's ARM64 cross-build can promote compiler-detected optional features
 # into the required CPU baseline. Keep the baseline to mandatory NEON on
 # Windows ARM; newer FP16/BF16/dot-product paths must stay optional and be

--- a/QtProject/vcpkg-triplets/arm64-windows-static-md-opencv-neon.cmake
+++ b/QtProject/vcpkg-triplets/arm64-windows-static-md-opencv-neon.cmake
@@ -1,0 +1,11 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# OpenCV's ARM64 cross-build can promote compiler-detected optional features
+# into the required CPU baseline. Keep the baseline to mandatory NEON on
+# Windows ARM; newer FP16/BF16/dot-product paths must stay optional and be
+# selected only when the runtime reports that the hardware supports them.
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS
+    "-DCPU_BASELINE=NEON"
+)


### PR DESCRIPTION
## Summary

- add a manual Windows packaging workflow for release-time runs
- build ARM64 and x64 MSIX packages in parallel on the stable `windows-2022` image
- cache vcpkg binary archives separately for each target architecture
- bundle the two MSIX packages after both builds complete
- retain generated packages for two days so they can be downloaded and submitted
- select the `ARM64` Visual Studio generator platform in the ARM64 preset
- pin vcpkg to a compatible commit with Qt 6.9.1, FFmpeg 7.1.2, and the NASM version required by the AOM port

## Runner choice

The workflow uses the x64 `windows-2022` image for both jobs. The image provides the stable Visual Studio 2022 toolchain and can cross-build the ARM64 target, avoiding a dependency on the public-preview Windows ARM runner.

## Validation

- JSON manifests parse successfully.
- `git diff --check` passes.
- GitHub Actions validation caught and fixed runner-context, vcpkg registry, cache-directory, and NASM/AOM issues in successive runs.
- The latest hosted run succeeded for both architectures and produced the bundle: https://github.com/theophanemayaud/video-simili-duplicate-cleaner/actions/runs/30258417961

The workflow is intentionally `workflow_dispatch`-only; run it on `master` after a release.