### PR TITLE
build(windows): use all available processors

### DIFF
--- a/QtProject/release-build/windows/package.json
+++ b/QtProject/release-build/windows/package.json
@@ -4,7 +4,7 @@
     "build-win-binaries-x64": "npm run cmake-configure-x64 && npm run cmake-build && npm run copy-exe && npm run prep-package-x64 && npm run package-app-x64",
     "cmake-configure-arm64": "cmake -S ..\\.. -B .\\build --preset vcpkg-arm64-static",
     "cmake-configure-x64": "cmake -S ..\\.. -B .\\build --preset vcpkg-x64-static",
-    "cmake-build": "cmake --build .\\build --config Release --target video-simili-duplicate-cleaner",
+    "cmake-build": "cmake --build .\\build --config Release --parallel %NUMBER_OF_PROCESSORS% --target video-simili-duplicate-cleaner",
     "copy-exe": "if not exist final mkdir final && copy .\\build\\Release\\video-simili-duplicate-cleaner.exe final\\\"Video simili duplicate cleaner.exe\"",
     "prep-package-arm64": "npm run icons && node process-manifest-template.js arm64 appxmanifest.template.xml final\\appxmanifest.xml",
     "prep-package-x64": "npm run icons && node process-manifest-template.js x64 appxmanifest.template.xml final\\appxmanifest.xml",


### PR DESCRIPTION
## Summary
- pass the Windows processor count to CMake for explicit parallel builds

## Why
- `cmake --build` previously relied on the native tool default, which did not guarantee use of the VM's available vCPUs

## Verification
- package JSON parses successfully
- `git diff --check` passes

This affects future Windows app builds only; it does not modify the currently running VM build.