### PR TITLE
perf(scan): skip videos that previously failed

### DIFF
--- a/.github/workflows/local-tests.yml
+++ b/.github/workflows/local-tests.yml
@@ -58,6 +58,7 @@ jobs:
           cmake --build QtProject/builds/ci-local-tests --target \
             test_comparison \
             test_mainwindow \
+            test_failed_video_cache \
             test_repo_auto_delete \
             test_repo_video_matching
 
@@ -65,7 +66,7 @@ jobs:
         run: |
           ctest --test-dir QtProject/builds/ci-local-tests \
             --output-on-failure \
-            -R "^(test_comparison|test_mainwindow|test_repo_auto_delete|test_repo_video_matching)$"
+            -R "^(test_comparison|test_mainwindow|test_failed_video_cache|test_repo_auto_delete|test_repo_video_matching)$"
 
   # We build univeralized static dependencies for macOS directly from latest macOS
   # That we then reuse for all macOS runners
@@ -169,6 +170,7 @@ jobs:
           cmake --build QtProject/builds/ci-macos-local-tests --target \
             test_comparison \
             test_mainwindow \
+            test_failed_video_cache \
             test_repo_auto_delete \
             test_repo_video_matching
 
@@ -176,4 +178,4 @@ jobs:
         run: |
           ctest --test-dir QtProject/builds/ci-macos-local-tests \
             --output-on-failure \
-            -R "^(test_comparison|test_mainwindow|test_repo_auto_delete|test_repo_video_matching)$"
+            -R "^(test_comparison|test_mainwindow|test_failed_video_cache|test_repo_auto_delete|test_repo_video_matching)$"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ The main development platform is macOS; keep default agent commands on this path
 - Run focused auto-delete end-to-end tests after changing cleanup behavior or auto cleanup UI:
   `cmake --build QtProject/builds/build-debug-6.10.1-macos --target test_repo_auto_delete && ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R ^test_repo_auto_delete$`
 - Run the self-contained CTest baseline:
-  `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R "^(test_comparison|test_mainwindow|test_repo_auto_delete|test_repo_video_matching)$"`
+  `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R "^(test_comparison|test_mainwindow|test_failed_video_cache|test_repo_auto_delete|test_repo_video_matching)$"`
+- Run `test_failed_video_cache` after changing which processing failures are treated as permanent versus retryable. It is self-contained and uses generated temporary files.
 - CTest labels make the safe lanes explicit: `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -L repo-fixtures` runs tracked fixtures, while `-L external-fixtures` runs the optional `~/Dev` suites. `test_external_large_video_corpus` is separately labeled `external-corpus` and `requires-mounted-100gb`; run only its named functions.
 - Green `test_external_whole_app_scan` function cases for regular external-corpus work: `emptyDb`, `test_whole_app_nocache`, `test_whole_app_cached`, `test_whole_app_cache_only`.
 - `test_repo_video_extraction_regression` compares platform-sensitive metadata/thumbnails for the Nice videos; run it on the macOS dev setup, not Linux CI, unless refreshing reference expectations.

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -271,6 +271,26 @@ void Db::writeMetadata(const Video& video) const
     }
 }
 
+void Db::writeFailure(const QString& filePathname, const QString& failure) const
+{
+    if (!_db.isOpen()) {
+        qDebug() << "Database not open, can't write Video failure.";
+        return;
+    }
+
+    QSqlQuery query(_db);
+    query.prepare("UPDATE metadata SET failure = :failure WHERE id = :id;");
+    query.bindValue(":failure", failure);
+    query.bindValue(":id", filePathname);
+    query.exec();
+
+    QSqlError error = query.lastError();
+    if (error.isValid()) {
+        qDebug() << "Error with writeFailure query for video=" << filePathname << " query=" << query.lastQuery();
+        qDebug() << error.text();
+    }
+}
+
 QByteArray Db::readCapture(const QString& filePathname, const int& percent) const
 {
     if (!_db.isOpen()) {

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -120,8 +120,11 @@ void Db::createTables(QSqlDatabase db, const QString appVersion)
                               "audio TEXT, "
                               "width INTEGER, "
                               "height INTEGER, "
-                              "additional_metadata TEXT"
+                              "additional_metadata TEXT, "
+                              "failure TEXT"
                               ");"));
+    // Existing caches created before failure lived on this row; duplicate-column errors are ignored.
+    query.exec(QStringLiteral("ALTER TABLE metadata ADD COLUMN failure TEXT"));
 
     query.exec(QStringLiteral("CREATE TABLE IF NOT EXISTS "
                               "capture ("
@@ -225,6 +228,7 @@ bool Db::readMetadata(Video& video) const
         }
         video.meta.additionalMetadata = map;
         video.meta.setRelevantValuesFromAdditionalMetadata();
+        video.cachedFailure = query.value(QStringLiteral("failure")).toString();
         return true;
     } // TODO : should proooobably delete others if there are multiple results !!! Or produce error !
     return false;
@@ -239,8 +243,8 @@ void Db::writeMetadata(const Video& video) const
 
     QSqlQuery query(_db);
     query.prepare("INSERT OR REPLACE INTO metadata "
-                  "(id, size, duration, bitrate, framerate, codec, audio, width, height, additional_metadata) "
-                  "VALUES(:id,:size,:duration,:bitrate,:framerate,:codec,:audio,:width,:height,:additional_metadata);");
+                  "(id, size, duration, bitrate, framerate, codec, audio, width, height, additional_metadata, failure) "
+                  "VALUES(:id,:size,:duration,:bitrate,:framerate,:codec,:audio,:width,:height,:additional_metadata,:failure);");
     query.bindValue(":id", video._filePathName);
     query.bindValue(":size", QVariant::fromValue(static_cast<qlonglong>(video.size)));
     query.bindValue(":duration", QVariant::fromValue(static_cast<qlonglong>(video.duration)));
@@ -256,6 +260,7 @@ void Db::writeMetadata(const Video& video) const
         vmap.insert(it.key(), it.value());
     QString jsonString = QJsonDocument(QJsonObject::fromVariantMap(vmap)).toJson(QJsonDocument::Compact);
     query.bindValue(":additional_metadata", jsonString);
+    query.bindValue(":failure", video.cachedFailure);
     query.exec();
 
     QSqlError error = query.lastError();

--- a/QtProject/app/db.h
+++ b/QtProject/app/db.h
@@ -44,10 +44,11 @@ class Db
     //constructor creates a database file if there is none already
     void createTables() const;
 
-    //return true and updates member variables if the video metadata was cached
+    // True when this path has a metadata row. video.cachedFailure is filled from that same row: empty means the
+    // cached properties are usable, otherwise processing already failed and can be skipped without another query.
     bool readMetadata(Video& video) const;
 
-    //save video properties in cache
+    //save video properties in cache, including any cachedFailure from a previous processing attempt
     void writeMetadata(const Video& video) const;
 
     //returns screen capture if it was cached, else return null ptr

--- a/QtProject/app/db.h
+++ b/QtProject/app/db.h
@@ -51,6 +51,10 @@ class Db
     //save video properties in cache, including any cachedFailure from a previous processing attempt
     void writeMetadata(const Video& video) const;
 
+    // Marks an already cached video as failed, leaving its metadata untouched. Does nothing when the video has no
+    // metadata row yet, which only leaves the failure unrecorded so the next scan processes the video again.
+    void writeFailure(const QString& filePathname, const QString& failure) const;
+
     //returns screen capture if it was cached, else return null ptr
     QByteArray readCapture(const QString& filePathname, const int& percent) const;
 

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -78,7 +78,7 @@ Video::ProcessingResult Video::process()
     result.success = false;
     result.video = this;
 
-    auto err = this->internalProcess();
+    const auto err = this->internalProcess();
     if (!err.isEmpty())
         result.errorMsg = err;
     else
@@ -107,6 +107,8 @@ QString Video::internalProcess()
     Db cache(_prefs.cacheFilePathName()); // we open the db here, but we'll only store things if needed
     if (this->_prefs.useCacheOption() != Prefs::NO_CACHE && cache.readMetadata(*this))
     {                                                       //check first if video properties are cached
+        if (!cachedFailure.isEmpty())
+            return QString("skipped, cache indicated it had failed in a previous scan: %1").arg(cachedFailure);
         modified = QFileInfo(_filePathName).lastModified(); // Db doesn't cache the modified date
         if (QFileInfo(_filePathName).birthTime().isValid())
             _fileCreateDate = QFileInfo(_filePathName).birthTime();
@@ -134,20 +136,31 @@ QString Video::internalProcess()
     if (width == 0
         || height == 0) // || duration == 0) // no duration check as we can infer duration when decoding frames,
     {
-        return QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
+        const QString error = QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
+        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE) {
+            cachedFailure = error;
+            cache.writeMetadata(*this);
+        }
+        return error;
     }
 
     auto err = takeScreenCaptures(cache);
     if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE && durationWasZero && duration != 0)
         cache.writeMetadata(*this); // update cache as takeScreenCaptures can estimate duration, when it was 0
     if (!err.isEmpty()) {
+        // A capture error can be an unavailable source or temporary resource failure, so let the next scan retry it.
         return QString("capture failed: %1").arg(err);
     }
     else if ((this->_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
              || // only cutEnds separates fingerprints for captures; other modes treat the collage as one fingerprint
              (this->_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
     { //all screen captures black
-        return "all screen captures black";
+        const QString error = "all screen captures black";
+        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE) {
+            cachedFailure = error;
+            cache.writeMetadata(*this);
+        }
+        return error;
     }
     else {
         return "";
@@ -300,6 +313,8 @@ const QString Video::takeScreenCaptures(const Db& cache)
         locker.unlock();
 
         ResolvedCapture resolved = resolveCaptureSlot(cache, percentages[capture], ofDuration);
+        if (!resolved.error.isEmpty())
+            return resolved.error;
 
         if (resolved.frame.isNull()) //taking screen capture may fail if video is broken
         {
@@ -382,8 +397,12 @@ Video::ResolvedCapture Video::resolveCaptureSlot(const Db& cache, const int perc
     const int substitutePercent = percentage < 50 ? percentage + _monochromeSubstituteOffset
                                                    : percentage - _monochromeSubstituteOffset;
     QImage substitute = ffmpegLib_captureAt(substitutePercent, ofDuration);
+    if (substitute.isNull()) {
+        resolved.error = QString("could not capture substitute frame at %1%").arg(percentage);
+        return resolved;
+    }
     const FrameAnalysis substituteAnalysis = VisualFingerprintBuilder::analyzeFrame(substitute);
-    if (!substitute.isNull() && substituteAnalysis.informative) {
+    if (substituteAnalysis.informative) {
         resolved.frame = std::move(substitute);
         resolved.analysis = substituteAnalysis;
         resolved.writeToCache = cacheEnabled;

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -28,9 +28,8 @@ int normalizedRightAngle(int angle)
 // Both describe the same presentation transform, so they must never be applied cumulatively.
 int presentationRotation(const ffmpeg::AVStream* stream)
 {
-    const ffmpeg::AVPacketSideData* sideData =
-        ffmpeg::av_packet_side_data_get(stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data,
-                                        ffmpeg::AV_PKT_DATA_DISPLAYMATRIX);
+    const ffmpeg::AVPacketSideData* sideData = ffmpeg::av_packet_side_data_get(
+        stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data, ffmpeg::AV_PKT_DATA_DISPLAYMATRIX);
     if (sideData != nullptr && sideData->size >= 9 * sizeof(int32_t)) {
         const double angle = ffmpeg::av_display_rotation_get(reinterpret_cast<const int32_t*>(sideData->data));
         if (!std::isnan(angle))
@@ -106,9 +105,9 @@ QString Video::internalProcess()
     // THEODEBUG : probably should re-implement things not to cache randomly !
     Db cache(_prefs.cacheFilePathName()); // we open the db here, but we'll only store things if needed
     if (this->_prefs.useCacheOption() != Prefs::NO_CACHE && cache.readMetadata(*this))
-    {                                                       //check first if video properties are cached
+    { //check first if video properties are cached
         if (!cachedFailure.isEmpty())
-            return QString("skipped, cache indicated it had failed in a previous scan: %1").arg(cachedFailure);
+            return QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure);
         modified = QFileInfo(_filePathName).lastModified(); // Db doesn't cache the modified date
         if (QFileInfo(_filePathName).birthTime().isValid())
             _fileCreateDate = QFileInfo(_filePathName).birthTime();
@@ -394,8 +393,8 @@ Video::ResolvedCapture Video::resolveCaptureSlot(const Db& cache, const int perc
     if (resolved.analysis.informative || !decodeAllowed)
         return resolved;
 
-    const int substitutePercent = percentage < 50 ? percentage + _monochromeSubstituteOffset
-                                                   : percentage - _monochromeSubstituteOffset;
+    const int substitutePercent =
+        percentage < 50 ? percentage + _monochromeSubstituteOffset : percentage - _monochromeSubstituteOffset;
     QImage substitute = ffmpegLib_captureAt(substitutePercent, ofDuration);
     if (substitute.isNull()) {
         resolved.error = QString("could not capture substitute frame at %1%").arg(percentage);
@@ -439,7 +438,7 @@ void Video::processThumbnail(QImage& thumbnail, const Thumbnail& thumb, const st
                 continue;
             }
             const QImage matchingImage = buildTransformedMatchingImage(thumbnail, thumb, width, height, firstCapture,
-                                                                        captureCount, columns, rows, crop, rotation);
+                                                                       captureCount, columns, rows, crop, rotation);
             fingerprints[segment][static_cast<int>(rotation)] =
                 VisualFingerprintBuilder::build(matchingImage, segmentUsable);
         }

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -136,10 +136,8 @@ QString Video::internalProcess()
         || height == 0) // || duration == 0) // no duration check as we can infer duration when decoding frames,
     {
         const QString error = QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
-        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE) {
-            cachedFailure = error;
-            cache.writeMetadata(*this);
-        }
+        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE)
+            cache.writeFailure(_filePathName, error);
         return error;
     }
 
@@ -155,10 +153,8 @@ QString Video::internalProcess()
              (this->_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
     { //every extracted frame have almost no features/fully flat (e.g. all black)
         const QString error = "all extracted frames were blank";
-        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE) {
-            cachedFailure = error;
-            cache.writeMetadata(*this);
-        }
+        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE)
+            cache.writeFailure(_filePathName, error);
         return error;
     }
     else {

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -295,6 +295,8 @@ const QString Video::takeScreenCaptures(const Db& cache)
 {
     Thumbnail thumb(this->_prefs.thumbnailsMode());
     QImage thumbnail(thumb.cols() * width, thumb.rows() * height, QImage::Format_RGB888);
+    if (thumbnail.isNull())
+        return "could not allocate thumbnail image";
     const QVector<int> percentages = thumb.percentages(); // percent from 1 to 100
     std::vector<FrameAnalysis> frameAnalyses(static_cast<size_t>(percentages.count()));
     int capture = percentages.count();

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -153,8 +153,8 @@ QString Video::internalProcess()
     else if ((this->_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
              || // only cutEnds separates fingerprints for captures; other modes treat the collage as one fingerprint
              (this->_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
-    { //all screen captures black
-        const QString error = "all screen captures black";
+    { //every extracted frame have almost no features/fully flat (e.g. all black)
+        const QString error = "all extracted frames were blank";
         if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE) {
             cachedFailure = error;
             cache.writeMetadata(*this);

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -393,7 +393,9 @@ Video::ResolvedCapture Video::resolveCaptureSlot(const Db& cache, const int perc
         percentage < 50 ? percentage + _monochromeSubstituteOffset : percentage - _monochromeSubstituteOffset;
     QImage substitute = ffmpegLib_captureAt(substitutePercent, ofDuration);
     if (substitute.isNull()) {
-        resolved.error = QString("could not capture substitute frame at %1%").arg(percentage);
+        resolved.error = QString("frame at %1% was blank and an attempted replacement at %2% could not be extracted")
+                             .arg(percentage)
+                             .arg(substitutePercent);
         return resolved;
     }
     const FrameAnalysis substituteAnalysis = VisualFingerprintBuilder::analyzeFrame(substitute);

--- a/QtProject/app/video.h
+++ b/QtProject/app/video.h
@@ -47,6 +47,10 @@ class Video : public QObject
     // filled at comparison time; TODO: consider scan-time extraction now that PhotoKit is fast
     QString nameInApplePhotos;
     int64_t size = 0; // in bytes
+    // Empty when the cached metadata is usable. A non-empty value means this path already failed processing, so the
+    // next scan can skip FFmpeg from the same readMetadata() call. Thumbnail mode is ignored: retrying is emptying
+    // the cache, or scanning without it.
+    QString cachedFailure;
     QDateTime modified;
     QDateTime _fileCreateDate;
     int64_t duration = 0; // in miliseconds
@@ -80,6 +84,9 @@ class Video : public QObject
         QImage frame;
         FrameAnalysis analysis;
         bool writeToCache = false;
+        // Set when a decode failed while looking for a better frame: the slot holds a usable frame, but the failure
+        // is transient, so the caller must abort instead of judging the video on the frame it happens to have.
+        QString error;
     };
 
     const QString getMetadata(const QString& filename); // returns error message or empty string if success

--- a/QtProject/app/video.h
+++ b/QtProject/app/video.h
@@ -47,9 +47,9 @@ class Video : public QObject
     // filled at comparison time; TODO: consider scan-time extraction now that PhotoKit is fast
     QString nameInApplePhotos;
     int64_t size = 0; // in bytes
-    // Empty when the cached metadata is usable. A non-empty value means this path already failed processing, so the
-    // next scan can skip FFmpeg from the same readMetadata() call. Thumbnail mode is ignored: retrying is emptying
-    // the cache, or scanning without it.
+    // Filled by readMetadata: empty when the cached metadata is usable, otherwise this path already failed processing
+    // and the scan can skip FFmpeg from that same query. Failures are recorded with Db::writeFailure. Thumbnail mode is
+    // ignored: retrying is emptying the cache, or scanning without it.
     QString cachedFailure;
     QDateTime modified;
     QDateTime _fileCreateDate;

--- a/QtProject/tests/CMakeLists.txt
+++ b/QtProject/tests/CMakeLists.txt
@@ -5,7 +5,9 @@ find_package(Qt6 REQUIRED COMPONENTS Test)
 set(TEST_COMPILE_DEFINITIONS
     VID_SIMILI_IN_TESTS
     QT_DISABLE_DEPRECATED_BEFORE=0x060000
-    APP_NAME="Video simili duplicate cleaner"
+    # APP_NAME scopes QSettings, so tests must not share the shipped app's name: they reset preferences between cases
+    # and would otherwise wipe the settings of a developer's installed copy.
+    APP_NAME="Video simili duplicate cleaner tests"
     APP_COPYRIGHT="Copyright © 2020-2025 Théophane Mayaud, 2018-2019 Kristian Koskimäki"
 )
 
@@ -87,23 +89,29 @@ function(add_qt_test TEST_NAME)
     )
 endfunction()
 
-# Test 1: test_comparison
+# test_comparison
 add_qt_test(test_comparison
     SOURCES test_comparison/tst_test_comparison.cpp
 )
 
-# Test 2: test_mainwindow (currently empty but structure is there)
+# test_mainwindow (currently empty but structure is there)
 add_qt_test(test_mainwindow
     SOURCES test_mainwindow/tst_mainwindow.cpp
 )
 
-# Test 3: checked-in fixture cleanup flow
+# failed-video negative cache uses generated temporary files and no fixture corpus
+add_qt_test(test_failed_video_cache
+    SOURCES test_failed_video_cache/tst_failed_video_cache.cpp
+)
+set_tests_properties(test_failed_video_cache PROPERTIES RUN_SERIAL TRUE)
+
+# checked-in fixture cleanup flow
 add_qt_test(test_repo_auto_delete
     SOURCES repo/auto_delete/tst_auto_delete.cpp
 )
 set_tests_properties(test_repo_auto_delete PROPERTIES LABELS "repo-fixtures")
 
-# Test 4: optional ~/Dev extraction and reference regression
+# optional ~/Dev extraction and reference regression
 add_qt_test(test_external_video_extraction_regression
     SOURCES
         external/video_extraction_regression/tst_video_extraction_regression.cpp
@@ -111,7 +119,7 @@ add_qt_test(test_external_video_extraction_regression
         shared/video_extraction_test_helpers.cpp
 )
 
-# Test 5: optional ~/Dev end-to-end whole-app scans
+# optional ~/Dev end-to-end whole-app scans
 add_qt_test(test_external_whole_app_scan
     SOURCES
         external/whole_app_scan/tst_whole_app_scan.cpp
@@ -122,7 +130,7 @@ set_tests_properties(test_external_video_extraction_regression test_external_who
     PROPERTIES LABELS "external-fixtures" RUN_SERIAL TRUE
 )
 
-# Test 6: separately mounted large corpus. Its functions can take 30+ minutes.
+# separately mounted large corpus. Its functions can take 30+ minutes.
 add_qt_test(test_external_large_video_corpus
     SOURCES
         external/large_video_corpus/tst_large_video_corpus.cpp
@@ -135,7 +143,7 @@ set_tests_properties(test_external_large_video_corpus PROPERTIES
     RUN_SERIAL TRUE
 )
 
-# Test 7: checked-in metadata and thumbnail extraction snapshots
+# checked-in metadata and thumbnail extraction snapshots
 add_qt_test(test_repo_video_extraction_regression
     SOURCES
         repo/video_extraction_regression/tst_video_extraction_regression.cpp
@@ -143,7 +151,7 @@ add_qt_test(test_repo_video_extraction_regression
 )
 set_tests_properties(test_repo_video_extraction_regression PROPERTIES LABELS "repo-fixtures")
 
-# Test 8: checked-in matching contract.
+# checked-in matching contract.
 add_qt_test(test_repo_video_matching
     SOURCES
         repo/video_matching/tst_video_matching.cpp
@@ -152,7 +160,7 @@ add_qt_test(test_repo_video_matching
 )
 set_tests_properties(test_repo_video_matching PROPERTIES LABELS "repo-fixtures")
 
-# Test 9: optional ~/Dev matching contract.
+# optional ~/Dev matching contract.
 add_qt_test(test_external_video_matching
     SOURCES
         external/video_matching/tst_video_matching.cpp

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -33,7 +33,7 @@ QString processError(const QString& path, const QString& cachePath, Prefs::USE_C
 // The message Video reports when the cached failure made it skip processing, so tests assert on one wording.
 QString skippedMessage(const QString& failure)
 {
-    return QString("skipped, cache indicated it had failed in a previous scan: %1").arg(failure);
+    return QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(failure);
 }
 
 bool writeInvalidVideo(const QString& path, const QByteArray& contents, QIODevice::OpenMode mode = QIODevice::WriteOnly)
@@ -224,19 +224,19 @@ void TestFailedVideoCache::test_failureSkipsUntilCacheBypassedOrEmptied()
     {
         Db cache(cachePath);
         writePlausibleMetadata(cache, prefs, videoPath, QFileInfo(videoPath).size(),
-                               QStringLiteral("all screen captures black"));
+                               QStringLiteral("all extracted frames were blank"));
     }
 
-    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all screen captures black"));
+    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all extracted frames were blank"));
     QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds),
-             skippedMessage(QStringLiteral("all screen captures black")));
+             skippedMessage(QStringLiteral("all extracted frames were blank")));
     QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, thumb1),
-             skippedMessage(QStringLiteral("all screen captures black")));
+             skippedMessage(QStringLiteral("all extracted frames were blank")));
 
     // Scanning without the cache must reach FFmpeg again, and must not record a new failure.
     const QString bypassedError = processError(videoPath, cachePath, Prefs::NO_CACHE, cutEnds);
     QVERIFY(bypassedError.contains(QStringLiteral("could not read metadata")));
-    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all screen captures black"));
+    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all extracted frames were blank"));
 
     QVERIFY(Db::emptyAllDb(prefs));
     QVERIFY(cachedFailure(cachePath, videoPath).isEmpty());

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -45,7 +45,7 @@ bool writeInvalidVideo(const QString& path, const QByteArray& contents, QIODevic
 }
 
 void writePlausibleMetadata(const Db& cache, const Prefs& prefs, const QString& path, qint64 size,
-                            const QString& failure = {})
+                            const QString& failure = {}, short width = 16, short height = 16)
 {
     Video metadata(prefs, path);
     metadata.size = size;
@@ -53,8 +53,8 @@ void writePlausibleMetadata(const Db& cache, const Prefs& prefs, const QString& 
     metadata.bitrate = 100;
     metadata.framerate = 25;
     metadata.codec = QStringLiteral("test");
-    metadata.width = 16;
-    metadata.height = 16;
+    metadata.width = width;
+    metadata.height = height;
     metadata.cachedFailure = failure;
     cache.writeMetadata(metadata);
 }
@@ -179,6 +179,28 @@ void TestFailedVideoCache::test_processingCachePolicy()
     QVERIFY(writeInvalidVideo(emptyPath, {}));
     QVERIFY(processError(emptyPath, cachePath, Prefs::WITH_CACHE, cutEnds).contains(QStringLiteral("file size = 0")));
     QVERIFY(cachedFailure(cachePath, emptyPath).isEmpty());
+
+    // Zero dimensions cannot become valid on a later scan, so the scan itself must record the failure, and it must do
+    // so without disturbing the metadata already cached for that path.
+    const QString zeroDimensionsPath = temporary.filePath(QStringLiteral("zero-dimensions.mp4"));
+    QVERIFY(writeInvalidVideo(zeroDimensionsPath, QByteArrayLiteral("not a video")));
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, zeroDimensionsPath, QFileInfo(zeroDimensionsPath).size(), {}, 0, 0);
+    }
+    const QString zeroDimensionsError = processError(zeroDimensionsPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(zeroDimensionsError.contains(QStringLiteral("= 0")));
+    QCOMPARE(cachedFailure(cachePath, zeroDimensionsPath), zeroDimensionsError);
+    {
+        Video cached(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), zeroDimensionsPath);
+        QVERIFY(Db(cachePath).readMetadata(cached));
+        QCOMPARE(cached.size, QFileInfo(zeroDimensionsPath).size());
+        QCOMPARE(cached.duration, 1000);
+        QCOMPARE(cached.bitrate, 100);
+        QCOMPARE(cached.codec, QStringLiteral("test"));
+    }
+    QCOMPARE(processError(zeroDimensionsPath, cachePath, Prefs::WITH_CACHE, cutEnds),
+             skippedMessage(zeroDimensionsError));
 }
 
 void TestFailedVideoCache::test_databaseClearingAndRemoval()

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -1,0 +1,250 @@
+#include <QBuffer>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "db.h"
+#include "prefs.h"
+#include "thumbnail.h"
+#include "video.h"
+
+namespace
+{
+Prefs cachePrefs(const QString& cachePath, Prefs::USE_CACHE_OPTION cacheOption, int thumbnailMode)
+{
+    Prefs prefs;
+    prefs.cacheFilePathName(cachePath);
+    prefs.useCacheOption(cacheOption);
+    prefs.thumbnailsMode(thumbnailMode);
+    prefs.appVersion = QStringLiteral("test");
+    return prefs;
+}
+
+QString processError(const QString& path, const QString& cachePath, Prefs::USE_CACHE_OPTION cacheOption,
+                     int thumbnailMode)
+{
+    const Prefs prefs = cachePrefs(cachePath, cacheOption, thumbnailMode);
+    Video video(prefs, path);
+    return video.process().errorMsg;
+}
+
+// The message Video reports when the cached failure made it skip processing, so tests assert on one wording.
+QString skippedMessage(const QString& failure)
+{
+    return QString("skipped, cache indicated it had failed in a previous scan: %1").arg(failure);
+}
+
+bool writeInvalidVideo(const QString& path, const QByteArray& contents, QIODevice::OpenMode mode = QIODevice::WriteOnly)
+{
+    QFile file(path);
+    if (!file.open(mode))
+        return false;
+    return file.write(contents) == contents.size();
+}
+
+void writePlausibleMetadata(const Db& cache, const Prefs& prefs, const QString& path, qint64 size,
+                            const QString& failure = {})
+{
+    Video metadata(prefs, path);
+    metadata.size = size;
+    metadata.duration = 1000;
+    metadata.bitrate = 100;
+    metadata.framerate = 25;
+    metadata.codec = QStringLiteral("test");
+    metadata.width = 16;
+    metadata.height = 16;
+    metadata.cachedFailure = failure;
+    cache.writeMetadata(metadata);
+}
+
+bool hasMetadata(const QString& cachePath, const QString& path)
+{
+    Video video(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), path);
+    return Db(cachePath).readMetadata(video);
+}
+
+QString cachedFailure(const QString& cachePath, const QString& path)
+{
+    Video video(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), path);
+    if (!Db(cachePath).readMetadata(video))
+        return {};
+    return video.cachedFailure;
+}
+
+QByteArray blackCapture()
+{
+    QImage image(16, 16, QImage::Format_RGB888);
+    image.fill(Qt::black);
+    QByteArray encoded;
+    QBuffer buffer(&encoded);
+    image.save(&buffer, QByteArrayLiteral("JPG"));
+    return encoded;
+}
+} // namespace
+
+class TestFailedVideoCache : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void init();
+    void cleanup();
+    void test_processingCachePolicy();
+    void test_databaseClearingAndRemoval();
+    void test_failureSkipsUntilCacheBypassedOrEmptied();
+};
+
+void TestFailedVideoCache::init()
+{
+    Prefs().resetSettings();
+}
+
+void TestFailedVideoCache::cleanup()
+{
+    Prefs().resetSettings();
+}
+
+void TestFailedVideoCache::test_processingCachePolicy()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString transientPath = temporary.filePath(QStringLiteral("transient.mp4"));
+    QVERIFY(writeInvalidVideo(transientPath, QByteArrayLiteral("not a video")));
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+
+    // Generic metadata/open failures may be environmental or transient, so unchanged files must remain retryable.
+    const QString firstMetadataError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(firstMetadataError.contains(QStringLiteral("could not read metadata")));
+    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
+    const QString secondMetadataError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(secondMetadataError.contains(QStringLiteral("could not read metadata")));
+    QVERIFY(!secondMetadataError.startsWith(QStringLiteral("skipped, cache indicated")));
+
+    // Cached metadata gets the invalid file into the capture/decode path, whose failures may also be transient.
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, transientPath, QFileInfo(transientPath).size());
+    }
+    const QString captureError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(captureError.contains(QStringLiteral("capture failed")));
+    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
+    const QString retryCaptureError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(retryCaptureError.contains(QStringLiteral("capture failed")));
+    QVERIFY(!retryCaptureError.startsWith(QStringLiteral("skipped, cache indicated")));
+
+    const QString otherModeError = processError(transientPath, cachePath, Prefs::WITH_CACHE, thumb1);
+    QVERIFY(otherModeError.contains(QStringLiteral("capture failed")));
+    QVERIFY(!otherModeError.startsWith(QStringLiteral("skipped, cache indicated")));
+
+    const QString noCacheError = processError(transientPath, cachePath, Prefs::NO_CACHE, cutEnds);
+    QVERIFY(noCacheError.contains(QStringLiteral("could not read metadata")));
+    QVERIFY(!noCacheError.startsWith(QStringLiteral("skipped, cache indicated")));
+    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
+
+    const QString cacheOnlyError = processError(transientPath, cachePath, Prefs::CACHE_ONLY, cutEnds);
+    QVERIFY(!cacheOnlyError.isEmpty());
+    QVERIFY(!cacheOnlyError.startsWith(QStringLiteral("skipped, cache indicated")));
+    const QString cacheOnlyMiss = processError(transientPath, cachePath, Prefs::CACHE_ONLY, thumb3);
+    QVERIFY(!cacheOnlyMiss.isEmpty());
+    QVERIFY(!cacheOnlyMiss.startsWith(QStringLiteral("skipped, cache indicated")));
+
+    const QString terminalPath = temporary.filePath(QStringLiteral("all-black.mp4"));
+    QVERIFY(writeInvalidVideo(terminalPath, QByteArrayLiteral("not a video")));
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, terminalPath, QFileInfo(terminalPath).size());
+        const QByteArray black = blackCapture();
+        for (const int percentage : Thumbnail(cutEnds).percentages())
+            cache.writeCapture(terminalPath, percentage, black);
+    }
+    // A substitute decode can fail temporarily even though the cached primary frame is black.
+    const QString substituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(substituteError.contains(QStringLiteral("could not capture substitute frame")));
+    QVERIFY(cachedFailure(cachePath, terminalPath).isEmpty());
+    const QString retrySubstituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(retrySubstituteError.contains(QStringLiteral("could not capture substitute frame")));
+    QVERIFY(!retrySubstituteError.startsWith(QStringLiteral("skipped, cache indicated")));
+
+    const QString missingPath = temporary.filePath(QStringLiteral("missing.mp4"));
+    QVERIFY(processError(missingPath, cachePath, Prefs::WITH_CACHE, cutEnds)
+                .contains(QStringLiteral("doesn't seem to exist")));
+    QVERIFY(!hasMetadata(cachePath, missingPath));
+
+    const QString emptyPath = temporary.filePath(QStringLiteral("empty.mp4"));
+    QVERIFY(writeInvalidVideo(emptyPath, {}));
+    QVERIFY(processError(emptyPath, cachePath, Prefs::WITH_CACHE, cutEnds).contains(QStringLiteral("file size = 0")));
+    QVERIFY(cachedFailure(cachePath, emptyPath).isEmpty());
+}
+
+void TestFailedVideoCache::test_databaseClearingAndRemoval()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+
+    const QString removedPath = temporary.filePath(QStringLiteral("removed.mp4"));
+    const QString keptPath = temporary.filePath(QStringLiteral("kept.mp4"));
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, removedPath, 1, QStringLiteral("removed"));
+        QVERIFY(cache.removeVideo(removedPath));
+        QVERIFY(!hasMetadata(cachePath, removedPath));
+
+        writePlausibleMetadata(cache, prefs, keptPath, 10, QStringLiteral("kept"));
+        cache.writeCapture(keptPath, 8, QByteArrayLiteral("kept capture"));
+        QVERIFY(cache.removeVideo(keptPath));
+
+        QVERIFY(!hasMetadata(cachePath, keptPath));
+        QVERIFY(cache.readCapture(keptPath, 8).isNull());
+
+        writePlausibleMetadata(cache, prefs, keptPath, 10, QStringLiteral("kept"));
+    }
+    QVERIFY(Db::emptyAllDb(prefs));
+    QVERIFY(!hasMetadata(cachePath, keptPath));
+}
+
+// Failure lives on the metadata row, so one readMetadata() both loads properties and decides whether to skip.
+// Thumbnail mode is ignored: retrying is bypassing the cache or emptying it.
+void TestFailedVideoCache::test_failureSkipsUntilCacheBypassedOrEmptied()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("broken.mp4"));
+    QVERIFY(writeInvalidVideo(videoPath, QByteArrayLiteral("not a video")));
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, videoPath, QFileInfo(videoPath).size(),
+                               QStringLiteral("all screen captures black"));
+    }
+
+    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all screen captures black"));
+    QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds),
+             skippedMessage(QStringLiteral("all screen captures black")));
+    QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, thumb1),
+             skippedMessage(QStringLiteral("all screen captures black")));
+
+    // Scanning without the cache must reach FFmpeg again, and must not record a new failure.
+    const QString bypassedError = processError(videoPath, cachePath, Prefs::NO_CACHE, cutEnds);
+    QVERIFY(bypassedError.contains(QStringLiteral("could not read metadata")));
+    QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all screen captures black"));
+
+    QVERIFY(Db::emptyAllDb(prefs));
+    QVERIFY(cachedFailure(cachePath, videoPath).isEmpty());
+    const QString retryError = processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(retryError.contains(QStringLiteral("could not read metadata")));
+    QVERIFY(!retryError.startsWith(QStringLiteral("skipped, cache indicated")));
+}
+
+QTEST_MAIN(TestFailedVideoCache)
+
+#include "tst_failed_video_cache.moc"

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -164,10 +164,10 @@ void TestFailedVideoCache::test_processingCachePolicy()
     }
     // A substitute decode can fail temporarily even though the cached primary frame is black.
     const QString substituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(substituteError.contains(QStringLiteral("could not capture substitute frame")));
+    QVERIFY(substituteError.contains(QStringLiteral("was blank and an attempted replacement")));
     QVERIFY(cachedFailure(cachePath, terminalPath).isEmpty());
     const QString retrySubstituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(retrySubstituteError.contains(QStringLiteral("could not capture substitute frame")));
+    QVERIFY(retrySubstituteError.contains(QStringLiteral("was blank and an attempted replacement")));
     QVERIFY(!retrySubstituteError.startsWith(QStringLiteral("skipped, cache indicated")));
 
     const QString missingPath = temporary.filePath(QStringLiteral("missing.mp4"));


### PR DESCRIPTION
Closes #91.

## What changed

- Add a nullable failure value to each video's existing metadata cache row.
- Read that value through the normal `readMetadata()` query, avoiding a second lookup for videos that process normally.
- Skip repeated FFmpeg work after deterministic failures: invalid decoded dimensions or unusable sampled frames.
- Keep metadata/open, capture/decode, missing-file, zero-size, Apple Photos eligibility, and cache-only errors retryable because they may be transient.

## Cache policy

A persisted failure behaves like any other cached video state. `WITH_CACHE` reads and writes it; `NO_CACHE` ignores it; **Empty cache** removes it. Thumbnail mode is deliberately ignored, so changing modes does not retry a failed video. There is no separate failure table, failure-specific clearing action, version key, signature invalidation, or additional database query.

Video processing retains its pre-existing cache lifecycle: one `Db` connection is opened inside `internalProcess()`. Deterministic failures are written at the point where they are identified, using that same connection and metadata row.

## Tests

- Add the self-contained `test_failed_video_cache` target to both CI local-test lanes.
- Cover deterministic failure persistence and skipping, transient failure retries, thumbnail-mode-independent skipping, `NO_CACHE`, `CACHE_ONLY`, missing and zero-size files, normal cache removal, and full cache clearing.
- Use a test-only application name so preference resets cannot affect an installed copy.
- Local macOS baseline passes: `test_comparison`, `test_mainwindow`, `test_failed_video_cache`, `test_repo_auto_delete`, and `test_repo_video_matching`.