### PR TITLE
chore(build): bootstrap new worktrees with linked build dependencies

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# `git worktree add` runs post-checkout with an all-zero previous HEAD, which is
+# how a brand new worktree is told apart from an ordinary branch checkout.
+if [ "$1" != "0000000000000000000000000000000000000000" ]; then
+	exit 0
+fi
+
+mainWorktree=$(cd -- "$(dirname -- "$(git rev-parse --git-common-dir)")" && pwd)
+if [ -z "$mainWorktree" ] || [ "$mainWorktree" = "$(pwd)" ]; then
+	exit 0
+fi
+
+# Build dependencies are gitignored for their size, so a fresh worktree has none
+# and cannot configure or build. Link rather than copy: they are several GB and
+# identical for every checkout, and CMake resolves them through these paths.
+for dependency in node_modules QtProject/libraries/macos/qt/qt-install; do
+	if [ -e "$mainWorktree/$dependency" ] && [ ! -e "$dependency" ]; then
+		mkdir -p "$(dirname "$dependency")"
+		ln -s "$mainWorktree/$dependency" "$dependency"
+		echo "post-checkout: linked $dependency from $mainWorktree"
+	fi
+done
+
+exit 0

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -14,7 +14,14 @@ fi
 # Build dependencies are gitignored for their size, so a fresh worktree has none
 # and cannot configure or build. Link rather than copy: they are several GB and
 # identical for every checkout, and CMake resolves them through these paths.
-for dependency in node_modules QtProject/libraries/macos/qt/qt-install; do
+# One path per line, relative to the checkout root. Paths cannot contain spaces:
+# the loop below relies on word splitting to read this list.
+dependencies="
+node_modules
+QtProject/libraries/macos/qt/qt-install
+"
+
+for dependency in $dependencies; do
 	if [ -e "$mainWorktree/$dependency" ] && [ ! -e "$dependency" ]; then
 		mkdir -p "$(dirname "$dependency")"
 		ln -s "$mainWorktree/$dependency" "$dependency"

--- a/QtProject/libraries/macos/qt/.gitignore
+++ b/QtProject/libraries/macos/qt/.gitignore
@@ -1,3 +1,4 @@
 qt-source/
 qt-build/
-qt-install/
+# No trailing slash: worktrees link this in rather than holding a real directory.
+qt-install


### PR DESCRIPTION
## Summary
- Add a Husky `post-checkout` hook that, when Git creates a new worktree, symlinks `node_modules` and `QtProject/libraries/macos/qt/qt-install` from the main checkout instead of leaving those gitignored paths empty.
- Ignore `qt-install` without a trailing slash so the worktree symlink is ignored, not only a real directory.

The previous copy lived in `.git/hooks/post-checkout` and never ran: `core.hooksPath` is `.husky/_`. This puts the logic on the path Git actually executes.

## How it works
`git worktree add` fires `post-checkout` with an all-zero previous HEAD. The hook then:
1. Resolves the main checkout from `git rev-parse --git-common-dir` (no hardcoded home path).
2. Symlinks the heavy, identical-across-checkouts build deps rather than copying several GB.

## Note
`.husky/_` is generated by `npm install` and is gitignored, so Git hooks only fire from a checkout that already has that directory (typically the main working tree). After this merges, new worktrees created from that main checkout will get the links. Worktrees created from a checkout that has no `.husky/_` still will not run hooks.

## Test plan
- [x] Created a throwaway worktree from a checkout that had the hook file and `.husky/_`; both `node_modules` and `qt-install` were linked.
- [x] Confirmed `git check-ignore` matches the `qt-install` symlink after dropping the trailing slash.
- [ ] After merge, from the main checkout (`npm install` so `.husky/_` exists), `git worktree add` a throwaway tree and confirm the two links appear and `git status` stays clean.


Made with [Cursor](https://cursor.com)