### PR TITLE
fix(scan): keep directory discovery responsive

### DIFF
--- a/QtProject/CMakeLists.txt
+++ b/QtProject/CMakeLists.txt
@@ -113,6 +113,8 @@ set(PROJECT_SOURCES
     app/mainwindow.cpp
     app/mainwindow.h
     app/mainwindow.ui
+    app/videodiscovery.cpp
+    app/videodiscovery.h
     app/video.cpp
     app/video.h
     app/visualfingerprint.cpp

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "prefs.h"
+#include <QDirIterator>
 #include <QProgressDialog>
 
 MainWindow::MainWindow() : ui(new Ui::MainWindow)
@@ -292,30 +293,32 @@ void MainWindow::findVideos(QDir& dir)
     dir.setNameFilters(_extensionList);
     // Sorting each folder would only cost time: results go into a set and processVideos sorts the final list.
     dir.setSorting(QDir::Unsorted);
+    // AllDirs so video globs still let us see every folder; Files keeps the globs on video names.
+    dir.setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
 
     QStringList remainingDirectories = directoriesToScanFor(dir);
     while (!remainingDirectories.isEmpty()) {
-        QDir currentDir = dir; // carries the extension filters and sorting over to each visited folder
+        QDir currentDir = dir; // carries the extension filters, sorting, and entry filter over to each visited folder
         currentDir.setPath(remainingDirectories.takeLast());
 
-        // Recursing by hand rather than with QDirIterator's Subdirectories flag is what makes pruning possible.
-        // QDir::AllDirs keeps the extension filters from being applied to folder names, and symlinked folders are
-        // left alone as QDirIterator did, which also rules out walking in circles.
-        const QFileInfoList subDirectories =
-            currentDir.entryInfoList(QDir::Dirs | QDir::AllDirs | QDir::NoDotAndDotDot);
-        for (const QFileInfo& subDirectory : subDirectories)
-            if (!subDirectory.isSymLink())
-                remainingDirectories.append(directoriesToScanFor(QDir(subDirectory.filePath())));
+        // One pass per folder, same as the old QDirIterator. Subdirectories is omitted so a .photoslibrary can
+        // be replaced by originals/ instead of walking resources/. Symlinked folders are left alone as before.
+        QDirIterator iter(currentDir);
+        while (iter.hasNext()) {
+            const QFileInfo entry = iter.nextFileInfo();
+            if (entry.isDir()) {
+                if (!entry.isSymLink())
+                    remainingDirectories.append(directoriesToScanFor(QDir(entry.filePath())));
+                continue;
+            }
 
-        const QFileInfoList videoFiles = currentDir.entryInfoList(QDir::Files);
-        for (const QFileInfo& videoFile : videoFiles) {
             QApplication::processEvents();
             if (_userPressedStop) {
                 _userPressedStop =
                     false; //user needs to press 2x to stop the find videos process, then process videos process.
                 return;
             }
-            const QString filePathName = videoFile.canonicalFilePath();
+            const QString filePathName = entry.canonicalFilePath();
 
             if (_everyVideo.contains(filePathName)) //don't want duplicates of same file
                 continue;

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -1,8 +1,8 @@
 #include "mainwindow.h"
 #include "prefs.h"
 #include <QElapsedTimer>
-#include <QPromise>
 #include <QProgressDialog>
+#include <QPromise>
 
 #include <limits>
 
@@ -12,9 +12,10 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     _prefs._mainwPtr = this;
 
     connect(Message::Get(), &Message::statusMessage, this, &MainWindow::addStatusMessage);
-    connect(&_videoDiscoveryWatcher, &QFutureWatcher<void>::progressTextChanged, this,
+    connect(&_videoDiscoveryWatcher, &QFutureWatcher<VideoDiscoveryResult>::progressTextChanged, this,
             [this](const QString& message) { ui->statusBar->showMessage(message); });
-    connect(&_videoDiscoveryWatcher, &QFutureWatcher<void>::finished, this, &MainWindow::videoDiscoveryFinished);
+    connect(&_videoDiscoveryWatcher, &QFutureWatcher<VideoDiscoveryResult>::finished, this,
+            &MainWindow::videoDiscoveryFinished);
 
     QFile file(":/version.txt");
     if (file.open(QIODevice::ReadOnly))
@@ -95,6 +96,24 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     connect(new QShortcut(QKeySequence::Close, this), &QShortcut::activated, this, &QApplication::quit);
 }
 
+MainWindow::~MainWindow()
+{
+    // The discovery callback reads _cancelVideoDiscovery, so keep this object alive until the worker has observed
+    // cancellation and returned its partial result.
+    _cancelVideoDiscovery = true;
+    _videoDiscoveryWatcher.waitForFinished();
+    deleteTemporaryFiles();
+    delete ui;
+}
+
+void MainWindow::closeEvent(QCloseEvent* event)
+{
+    _windowClosing = true;
+    _stopVideoProcessing = true;
+    _cancelVideoDiscovery = true;
+    QMainWindow::closeEvent(event);
+}
+
 void MainWindow::deleteTemporaryFiles() const
 {
     QDir tempDir = QDir::tempPath(); //QTemporaryDir remains if program force quit
@@ -109,25 +128,17 @@ void MainWindow::deleteTemporaryFiles() const
 
 void MainWindow::loadExtensions()
 {
-    //DEBUGTHEO for windows QFile file(QStringLiteral("%1/extensions.ini").arg(QApplication::applicationDirPath()));
-    //But for mac here it is
-    //Working on mac : QFile file(QStringLiteral("%1/../Frameworks/extensions.ini").arg(QApplication::applicationDirPath()));
-    //Test witth qrc file with extensions.ini at / :
-    QFile file(QStringLiteral(":/extensions.ini")); //using qrc ressource path ! This works on mac at least !
-    if (!file.open(QIODevice::ReadOnly)) {
+    _extensionList = loadVideoExtensionFilters();
+    if (_extensionList.isEmpty()) {
         addStatusMessage(QStringLiteral("Error: extensions.ini not found. No video file will be searched."));
         return;
     }
+
     addStatusMessage(QStringLiteral("Currently supported file extensions:"));
-    QTextStream text(&file);
-    while (!text.atEnd()) {
-        QString line = text.readLine();
-        if (line.startsWith(QStringLiteral(";")) || line.isEmpty())
-            continue;
-        _extensionList << line.replace(QRegularExpression("\\*?\\."), "*.").split(QStringLiteral(" "));
-        addStatusMessage(line.remove(QStringLiteral("*")));
-    }
-    file.close();
+    QStringList displayExtensions = _extensionList;
+    for (QString& extension : displayExtensions)
+        extension.remove(u'*');
+    addStatusMessage(displayExtensions.join(u' '));
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -186,20 +197,20 @@ void MainWindow::on_directoryBox_textChanged(const QString& arg1)
 void MainWindow::on_findDuplicates_clicked()
 {
     if (ui->findDuplicates->text() == "Stop") //pressing "find duplicates" button will morph into a
-    {                                         //stop button. a lengthy search can thus be stopped and
-        _userPressedStop = true;              //those videos already processed are compared w/each other
-        _videoDiscoveryWatcher.cancel();
+    {                                         //stop button. a lengthy search can thus be stopped.
+        if (_videoDiscoveryWatcher.isRunning())
+            _cancelVideoDiscovery = true;
+        else
+            _stopVideoProcessing = true;
         return;
-    }
-    else {
-        ui->findDuplicates->setText(QStringLiteral("Stop"));
-        _userPressedStop = false;
     }
     if (_extensionList.isEmpty()) {
         addStatusMessage(
             QStringLiteral("Error: No extensions found in extensions.ini. No video file will be searched."));
         return;
     }
+    ui->findDuplicates->setText(QStringLiteral("Stop"));
+    _stopVideoProcessing = false;
 
     if (_videoList.count() == 0)
         this->shouldScan = true;
@@ -276,43 +287,43 @@ void MainWindow::startVideoDiscovery(const QStringList& directories)
     ui->browseFolders->setDisabled(true);
     ui->browseApplePhotos->setDisabled(true);
 
-    _videoDiscoveryResult = std::make_shared<VideoDiscoveryResult>();
-    const auto result = _videoDiscoveryResult;
-    const QStringList nameFilters = _extensionList;
+    _cancelVideoDiscovery = false;
+    const QStringList extensionFilters = _extensionList;
 
-    _videoDiscoveryWatcher.setFuture(
-        QtConcurrent::run([directories, nameFilters, result](QPromise<void>& promise) {
-            promise.setProgressRange(0, std::numeric_limits<int>::max());
-            QElapsedTimer progressTimer;
-            progressTimer.start();
-            int progressSequence = 0;
+    _videoDiscoveryWatcher.setFuture(QtConcurrent::run([this, directories,
+                                                        extensionFilters](QPromise<VideoDiscoveryResult>& promise) {
+        promise.setProgressRange(0, std::numeric_limits<int>::max());
+        QElapsedTimer progressTimer;
+        progressTimer.start();
+        int progressSequence = 0;
 
-            *result = discoverVideos(directories, nameFilters, [&](int videoCount, const QString& path) {
-                if (promise.isCanceled())
+        VideoDiscoveryResult result =
+            discoverVideos(directories, extensionFilters, [&](int videoCount, const QString& path) {
+                if (_cancelVideoDiscovery)
                     return false;
 
                 // Human-readable progress does not benefit from repainting at display refresh rate. Ten updates per
                 // second stay responsive while avoiding timer churn and event processing for every discovered video.
                 if (progressTimer.elapsed() >= 100) {
                     promise.setProgressValueAndText(
-                        ++progressSequence, QStringLiteral("Found %1 videos | %2")
-                                                .arg(videoCount)
-                                                .arg(QDir::toNativeSeparators(path)));
+                        ++progressSequence,
+                        QStringLiteral("Found %1 videos | %2").arg(videoCount).arg(QDir::toNativeSeparators(path)));
                     progressTimer.restart();
                 }
                 return true;
             });
-        }));
+        promise.addResult(std::move(result));
+    }));
 }
 
 void MainWindow::videoDiscoveryFinished()
 {
-    if (_windowClosing || !_videoDiscoveryResult)
+    if (_windowClosing)
         return;
 
-    _everyVideo = std::move(_videoDiscoveryResult->videos);
-    const QStringList missingDirectories = std::move(_videoDiscoveryResult->missingDirectories);
-    _videoDiscoveryResult.reset();
+    VideoDiscoveryResult result = _videoDiscoveryWatcher.result();
+    _everyVideo = std::move(result.videos);
+    const QStringList missingDirectories = std::move(result.missingDirectories);
 
     for (const QString& missingDirectory : missingDirectories)
         addStatusMessage(QStringLiteral("Cannot find folder: %1").arg(missingDirectory));
@@ -321,7 +332,6 @@ void MainWindow::videoDiscoveryFinished()
             QStringLiteral("Cannot find folder: %1").arg(missingDirectories.join(QStringLiteral(" "))));
 
     // Preserve the existing Stop behavior: process and compare videos found before directory discovery stopped.
-    _userPressedStop = false;
     processVideos();
     finishFindDuplicates();
 }
@@ -379,7 +389,7 @@ void MainWindow::processVideos()
         // Wait if we have too many active tasks
         while (activeFutures.size() >= 2 * maxParallelTasks)
         { // double to schedule some tasks in advance so QT can immediately run them when a thread frees up
-            if (this->_userPressedStop)
+            if (this->_stopVideoProcessing)
                 break;
             // Check completed futures and process their results
             for (int i = activeFutures.size() - 1; i >= 0; --i) { // reverse iteration as we remove in place from list
@@ -395,7 +405,7 @@ void MainWindow::processVideos()
             QThread::msleep(10); // Small sleep to avoid busy-waiting
         }
 
-        if (this->_userPressedStop)
+        if (this->_stopVideoProcessing)
             break;
 
         // Create video and submit for processing
@@ -416,7 +426,7 @@ void MainWindow::processVideos()
     QElapsedTimer timer;
     timer.start();
     while (!activeFutures.isEmpty()) {
-        if (this->_userPressedStop && this->ui->findDuplicates->isEnabled()) {
+        if (this->_stopVideoProcessing && this->ui->findDuplicates->isEnabled()) {
             this->ui->findDuplicates->setText(QStringLiteral("Stopping..."));
             this->ui->findDuplicates->setDisabled(true);
         }
@@ -432,7 +442,7 @@ void MainWindow::processVideos()
         }
         progress.setValue(progress.maximum() - activeFutures.size());
         QApplication::processEvents();
-        if (this->_userPressedStop && timer.elapsed() > 60000) { // 60 seconds
+        if (this->_stopVideoProcessing && timer.elapsed() > 60000) { // 60 seconds
             // Memory leak occurs here but that's small enough to not be a big deal.
             addStatusMessage(QString("Warning: Video processing took too long after user pressed stop (more than 60 "
                                      "seconds), ignoring remaining ones."));

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -270,11 +270,6 @@ void MainWindow::finishFindDuplicates()
     this->shouldScan = false; //set to false, as we are done scanning
 }
 
-void MainWindow::findVideos(QDir& dir)
-{
-    _everyVideo.unite(discoverVideos({dir.path()}, _extensionList).videos);
-}
-
 void MainWindow::startVideoDiscovery(const QStringList& directories)
 {
     ui->directoryBox->setDisabled(true);

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -268,26 +268,64 @@ void MainWindow::on_findDuplicates_clicked()
     this->shouldScan = false; //set to false, as we are done scanning
 }
 
+namespace
+{
+// Photos keeps a derivative and a thumbnail for every asset, so a real library holds hundreds of thousands of files
+// under resources/ while only originals/ can hold a video worth reviewing: Video::internalProcess rejects anything
+// outside originals/ as a derivative. Enumerating the rest froze the UI for around 25s on a 440k entry library and
+// every one of those entries was then discarded, so the whole library is replaced by its originals/ folder.
+// A library without originals/ holds nothing we would accept, hence an empty result rather than a full walk.
+QStringList directoriesToScanFor(const QDir& dir)
+{
+    if (!dir.dirName().endsWith(QStringLiteral(".photoslibrary")))
+        return {dir.path()};
+
+    const QString originals = dir.filePath(QStringLiteral("originals"));
+    if (!QFileInfo(originals).isDir())
+        return {};
+    return {originals};
+}
+} // namespace
+
 void MainWindow::findVideos(QDir& dir)
 {
     dir.setNameFilters(_extensionList);
-    QDirIterator iter(dir, QDirIterator::Subdirectories);
-    while (iter.hasNext()) {
-        QApplication::processEvents();
-        if (_userPressedStop) {
-            _userPressedStop =
-                false; //user needs to press 2x to stop the find videos process, then process videos process.
-            return;
+    // Sorting each folder would only cost time: results go into a set and processVideos sorts the final list.
+    dir.setSorting(QDir::Unsorted);
+
+    QStringList remainingDirectories = directoriesToScanFor(dir);
+    while (!remainingDirectories.isEmpty()) {
+        QDir currentDir = dir; // carries the extension filters and sorting over to each visited folder
+        currentDir.setPath(remainingDirectories.takeLast());
+
+        // Recursing by hand rather than with QDirIterator's Subdirectories flag is what makes pruning possible.
+        // QDir::AllDirs keeps the extension filters from being applied to folder names, and symlinked folders are
+        // left alone as QDirIterator did, which also rules out walking in circles.
+        const QFileInfoList subDirectories =
+            currentDir.entryInfoList(QDir::Dirs | QDir::AllDirs | QDir::NoDotAndDotDot);
+        for (const QFileInfo& subDirectory : subDirectories)
+            if (!subDirectory.isSymLink())
+                remainingDirectories.append(directoriesToScanFor(QDir(subDirectory.filePath())));
+
+        const QFileInfoList videoFiles = currentDir.entryInfoList(QDir::Files);
+        for (const QFileInfo& videoFile : videoFiles) {
+            QApplication::processEvents();
+            if (_userPressedStop) {
+                _userPressedStop =
+                    false; //user needs to press 2x to stop the find videos process, then process videos process.
+                return;
+            }
+            const QString filePathName = videoFile.canonicalFilePath();
+
+            if (_everyVideo.contains(filePathName)) //don't want duplicates of same file
+                continue;
+            _everyVideo.insert(filePathName);
+
+            ui->statusBar->showMessage(QStringLiteral("Found %1 videos | %2")
+                                           .arg(_everyVideo.size())
+                                           .arg(QDir::toNativeSeparators(filePathName)),
+                                       10);
         }
-        const QString filePathName = iter.nextFileInfo().canonicalFilePath();
-
-        if (_everyVideo.contains(filePathName)) //don't want duplicates of same file
-            continue;
-        _everyVideo.insert(filePathName);
-
-        ui->statusBar->showMessage(
-            QStringLiteral("Found %1 videos | %2").arg(_everyVideo.size()).arg(QDir::toNativeSeparators(filePathName)),
-            10);
     }
 }
 

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -1,7 +1,10 @@
 #include "mainwindow.h"
 #include "prefs.h"
-#include <QDirIterator>
+#include <QElapsedTimer>
+#include <QPromise>
 #include <QProgressDialog>
+
+#include <limits>
 
 MainWindow::MainWindow() : ui(new Ui::MainWindow)
 {
@@ -9,6 +12,9 @@ MainWindow::MainWindow() : ui(new Ui::MainWindow)
     _prefs._mainwPtr = this;
 
     connect(Message::Get(), &Message::statusMessage, this, &MainWindow::addStatusMessage);
+    connect(&_videoDiscoveryWatcher, &QFutureWatcher<void>::progressTextChanged, this,
+            [this](const QString& message) { ui->statusBar->showMessage(message); });
+    connect(&_videoDiscoveryWatcher, &QFutureWatcher<void>::finished, this, &MainWindow::videoDiscoveryFinished);
 
     QFile file(":/version.txt");
     if (file.open(QIODevice::ReadOnly))
@@ -182,6 +188,7 @@ void MainWindow::on_findDuplicates_clicked()
     if (ui->findDuplicates->text() == "Stop") //pressing "find duplicates" button will morph into a
     {                                         //stop button. a lengthy search can thus be stopped and
         _userPressedStop = true;              //those videos already processed are compared w/each other
+        _videoDiscoveryWatcher.cancel();
         return;
     }
     else {
@@ -213,6 +220,7 @@ void MainWindow::on_findDuplicates_clicked()
 
     if (this->shouldScan) {
         addStatusMessage(QStringLiteral("\n\rSearching for videos..."));
+        ui->statusBar->showMessage(QStringLiteral("Searching for videos..."));
         ui->statusBar->setVisible(true);
 
         for (const auto& video : _videoList) //new search: delete videos from previous search
@@ -225,23 +233,8 @@ void MainWindow::on_findDuplicates_clicked()
         this->_prefs.scanLocations(directories);
         Message::Get()->add(QStringLiteral("Re scanning: %1").arg(directories.join(", ")));
         if (this->_prefs.useCacheOption() != Prefs::CACHE_ONLY) {
-            QString notFound;
-            for (auto directory : directories) //add all video files from entered paths to list
-            {
-                QApplication::processEvents();
-                if (directory.isEmpty())
-                    continue;
-                QDir dir = directory.remove(QStringLiteral("\""));
-                if (dir.exists())
-                    findVideos(dir);
-                else {
-                    addStatusMessage(
-                        QStringLiteral("Cannot find folder: %1").arg(QDir::toNativeSeparators(dir.path())));
-                    notFound += QStringLiteral("%1 ").arg(QDir::toNativeSeparators(dir.path()));
-                }
-            }
-            if (!notFound.isEmpty())
-                ui->statusBar->showMessage(QStringLiteral("Cannot find folder: %1").arg(notFound));
+            startVideoDiscovery(directories);
+            return;
         }
         else
             _everyVideo = Db(_prefs.cacheFilePathName()).getCachedVideoPathnamesInFolders(directories);
@@ -249,6 +242,11 @@ void MainWindow::on_findDuplicates_clicked()
         processVideos();
     }
 
+    finishFindDuplicates();
+}
+
+void MainWindow::finishFindDuplicates()
+{
     if (_videoList.count() > 1) {
         this->_comparison = new Comparison(this->_videoList, this->_prefs, this->geometry());
         this->_comparison->hide();
@@ -266,70 +264,66 @@ void MainWindow::on_findDuplicates_clicked()
 
     ui->findDuplicates->setText(QStringLiteral("Find duplicates"));
     ui->findDuplicates->setDisabled(false);
+    ui->directoryBox->setDisabled(false);
+    ui->browseFolders->setDisabled(false);
+    ui->browseApplePhotos->setDisabled(false);
     this->shouldScan = false; //set to false, as we are done scanning
 }
 
-namespace
+void MainWindow::startVideoDiscovery(const QStringList& directories)
 {
-// Photos keeps a derivative and a thumbnail for every asset, so a real library holds hundreds of thousands of files
-// under resources/ while only originals/ can hold a video worth reviewing: Video::internalProcess rejects anything
-// outside originals/ as a derivative. Enumerating the rest froze the UI for around 25s on a 440k entry library and
-// every one of those entries was then discarded, so the whole library is replaced by its originals/ folder.
-// A library without originals/ holds nothing we would accept, hence an empty result rather than a full walk.
-QStringList directoriesToScanFor(const QDir& dir)
-{
-    if (!dir.dirName().endsWith(QStringLiteral(".photoslibrary")))
-        return {dir.path()};
+    ui->directoryBox->setDisabled(true);
+    ui->browseFolders->setDisabled(true);
+    ui->browseApplePhotos->setDisabled(true);
 
-    const QString originals = dir.filePath(QStringLiteral("originals"));
-    if (!QFileInfo(originals).isDir())
-        return {};
-    return {originals};
+    _videoDiscoveryResult = std::make_shared<VideoDiscoveryResult>();
+    const auto result = _videoDiscoveryResult;
+    const QStringList nameFilters = _extensionList;
+
+    _videoDiscoveryWatcher.setFuture(
+        QtConcurrent::run([directories, nameFilters, result](QPromise<void>& promise) {
+            promise.setProgressRange(0, std::numeric_limits<int>::max());
+            QElapsedTimer progressTimer;
+            progressTimer.start();
+            int progressSequence = 0;
+
+            *result = discoverVideos(directories, nameFilters, [&](int videoCount, const QString& path) {
+                if (promise.isCanceled())
+                    return false;
+
+                // Human-readable progress does not benefit from repainting at display refresh rate. Ten updates per
+                // second stay responsive while avoiding timer churn and event processing for every discovered video.
+                if (progressTimer.elapsed() >= 100) {
+                    promise.setProgressValueAndText(
+                        ++progressSequence, QStringLiteral("Found %1 videos | %2")
+                                                .arg(videoCount)
+                                                .arg(QDir::toNativeSeparators(path)));
+                    progressTimer.restart();
+                }
+                return true;
+            });
+        }));
 }
-} // namespace
 
-void MainWindow::findVideos(QDir& dir)
+void MainWindow::videoDiscoveryFinished()
 {
-    dir.setNameFilters(_extensionList);
-    // Sorting each folder would only cost time: results go into a set and processVideos sorts the final list.
-    dir.setSorting(QDir::Unsorted);
-    // AllDirs so video globs still let us see every folder; Files keeps the globs on video names.
-    dir.setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
+    if (_windowClosing || !_videoDiscoveryResult)
+        return;
 
-    QStringList remainingDirectories = directoriesToScanFor(dir);
-    while (!remainingDirectories.isEmpty()) {
-        QDir currentDir = dir; // carries the extension filters, sorting, and entry filter over to each visited folder
-        currentDir.setPath(remainingDirectories.takeLast());
+    _everyVideo = std::move(_videoDiscoveryResult->videos);
+    const QStringList missingDirectories = std::move(_videoDiscoveryResult->missingDirectories);
+    _videoDiscoveryResult.reset();
 
-        // One pass per folder, same as the old QDirIterator. Subdirectories is omitted so a .photoslibrary can
-        // be replaced by originals/ instead of walking resources/. Symlinked folders are left alone as before.
-        QDirIterator iter(currentDir);
-        while (iter.hasNext()) {
-            const QFileInfo entry = iter.nextFileInfo();
-            if (entry.isDir()) {
-                if (!entry.isSymLink())
-                    remainingDirectories.append(directoriesToScanFor(QDir(entry.filePath())));
-                continue;
-            }
+    for (const QString& missingDirectory : missingDirectories)
+        addStatusMessage(QStringLiteral("Cannot find folder: %1").arg(missingDirectory));
+    if (!missingDirectories.isEmpty())
+        ui->statusBar->showMessage(
+            QStringLiteral("Cannot find folder: %1").arg(missingDirectories.join(QStringLiteral(" "))));
 
-            QApplication::processEvents();
-            if (_userPressedStop) {
-                _userPressedStop =
-                    false; //user needs to press 2x to stop the find videos process, then process videos process.
-                return;
-            }
-            const QString filePathName = entry.canonicalFilePath();
-
-            if (_everyVideo.contains(filePathName)) //don't want duplicates of same file
-                continue;
-            _everyVideo.insert(filePathName);
-
-            ui->statusBar->showMessage(QStringLiteral("Found %1 videos | %2")
-                                           .arg(_everyVideo.size())
-                                           .arg(QDir::toNativeSeparators(filePathName)),
-                                       10);
-        }
-    }
+    // Preserve the existing Stop behavior: process and compare videos found before directory discovery stopped.
+    _userPressedStop = false;
+    processVideos();
+    finishFindDuplicates();
 }
 
 void MainWindow::processVideos()

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -348,8 +348,15 @@ void MainWindow::processVideos()
         ui->progressBar->setMaximum(_prefs._numberOfVideos);
         ui->statusBox->verticalScrollBar()->triggerAction(QScrollBar::SliderToMaximum);
     }
-    else
+    else {
+        // Nothing to process, so "Searching for videos..." has to go: leaving it up makes an idle window look like it
+        // is still scanning. A missing-folder warning is the one message worth keeping on screen.
+        if (ui->statusBar->currentMessage().indexOf(QStringLiteral("Cannot find folder")) == -1) {
+            ui->statusBar->clearMessage();
+            ui->statusBar->setVisible(false);
+        }
         return;
+    }
 
     // Process videos using QtConcurrent
     // for reproduceability and easier user experience, we want to process videos in alphabetical order

--- a/QtProject/app/mainwindow.cpp
+++ b/QtProject/app/mainwindow.cpp
@@ -270,6 +270,11 @@ void MainWindow::finishFindDuplicates()
     this->shouldScan = false; //set to false, as we are done scanning
 }
 
+void MainWindow::findVideos(QDir& dir)
+{
+    _everyVideo.unite(discoverVideos({dir.path()}, _extensionList).videos);
+}
+
 void MainWindow::startVideoDiscovery(const QStringList& directories)
 {
     ui->directoryBox->setDisabled(true);

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -88,6 +88,7 @@ class MainWindow : public QMainWindow
     void on_browseApplePhotos_clicked();
     void on_directoryBox_returnPressed() { on_findDuplicates_clicked(); }
     void on_findDuplicates_clicked();
+    void findVideos(QDir& dir);
     void startVideoDiscovery(const QStringList& directories);
     void videoDiscoveryFinished();
     void finishFindDuplicates();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -26,6 +26,7 @@ class MainWindow : public QMainWindow
 
     friend class VideoCorpusTestHelpers;
     friend class TestAutoDelete;
+    friend class TestMainWindow;
 
   public:
     MainWindow();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -4,9 +4,12 @@
 #include <QDesktopServices>
 #include <QDragEnterEvent>
 #include <QFileDialog>
+#include <QFutureWatcher>
 #include <QMimeData>
 #include <QScrollBar>
 #include <QtConcurrent/QtConcurrent>
+
+#include <memory>
 
 #include "ui_mainwindow.h"
 
@@ -14,6 +17,7 @@
 #include "db.h"
 #include "prefs.h"
 #include "video.h"
+#include "videodiscovery.h"
 
 namespace Ui
 {
@@ -26,7 +30,6 @@ class MainWindow : public QMainWindow
 
     friend class VideoCorpusTestHelpers;
     friend class TestAutoDelete;
-    friend class TestMainWindow;
 
   public:
     MainWindow();
@@ -44,17 +47,22 @@ class MainWindow : public QMainWindow
     QSet<QString> _everyVideo; // set as we need to avoid duplicates
     QStringList _rejectedVideos;
     QStringList _extensionList;
+    QFutureWatcher<void> _videoDiscoveryWatcher;
+    std::shared_ptr<VideoDiscoveryResult> _videoDiscoveryResult;
 
     Prefs _prefs;
     bool _userPressedStop = false;
     bool shouldScan = true;
+    bool _windowClosing = false;
 
   private slots:
     void deleteTemporaryFiles() const;
     void closeEvent(QCloseEvent* event)
     {
         Q_UNUSED(event)
+        _windowClosing = true;
         _userPressedStop = true;
+        _videoDiscoveryWatcher.cancel();
     }
     void dragEnterEvent(QDragEnterEvent* event)
     {
@@ -80,7 +88,9 @@ class MainWindow : public QMainWindow
     void on_browseApplePhotos_clicked();
     void on_directoryBox_returnPressed() { on_findDuplicates_clicked(); }
     void on_findDuplicates_clicked();
-    void findVideos(QDir& dir);
+    void startVideoDiscovery(const QStringList& directories);
+    void videoDiscoveryFinished();
+    void finishFindDuplicates();
     void processVideos();
     void videoSummary();
 

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -30,6 +30,7 @@ class MainWindow : public QMainWindow
 
     friend class VideoCorpusTestHelpers;
     friend class TestAutoDelete;
+    friend class TestMainWindow;
 
   public:
     MainWindow();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -88,7 +88,6 @@ class MainWindow : public QMainWindow
     void on_browseApplePhotos_clicked();
     void on_directoryBox_returnPressed() { on_findDuplicates_clicked(); }
     void on_findDuplicates_clicked();
-    void findVideos(QDir& dir);
     void startVideoDiscovery(const QStringList& directories);
     void videoDiscoveryFinished();
     void finishFindDuplicates();

--- a/QtProject/app/mainwindow.h
+++ b/QtProject/app/mainwindow.h
@@ -9,7 +9,7 @@
 #include <QScrollBar>
 #include <QtConcurrent/QtConcurrent>
 
-#include <memory>
+#include <atomic>
 
 #include "ui_mainwindow.h"
 
@@ -30,15 +30,10 @@ class MainWindow : public QMainWindow
 
     friend class VideoCorpusTestHelpers;
     friend class TestAutoDelete;
-    friend class TestMainWindow;
 
   public:
     MainWindow();
-    ~MainWindow()
-    {
-        deleteTemporaryFiles();
-        delete ui;
-    }
+    ~MainWindow() override;
 
   private:
     Ui::MainWindow* ui;
@@ -48,29 +43,23 @@ class MainWindow : public QMainWindow
     QSet<QString> _everyVideo; // set as we need to avoid duplicates
     QStringList _rejectedVideos;
     QStringList _extensionList;
-    QFutureWatcher<void> _videoDiscoveryWatcher;
-    std::shared_ptr<VideoDiscoveryResult> _videoDiscoveryResult;
+    QFutureWatcher<VideoDiscoveryResult> _videoDiscoveryWatcher;
+    std::atomic_bool _cancelVideoDiscovery = false;
 
     Prefs _prefs;
-    bool _userPressedStop = false;
+    bool _stopVideoProcessing = false;
     bool shouldScan = true;
     bool _windowClosing = false;
 
   private slots:
     void deleteTemporaryFiles() const;
-    void closeEvent(QCloseEvent* event)
-    {
-        Q_UNUSED(event)
-        _windowClosing = true;
-        _userPressedStop = true;
-        _videoDiscoveryWatcher.cancel();
-    }
-    void dragEnterEvent(QDragEnterEvent* event)
+    void closeEvent(QCloseEvent* event) override;
+    void dragEnterEvent(QDragEnterEvent* event) override
     {
         if (event->mimeData()->hasUrls())
             event->acceptProposedAction();
     }
-    void dropEvent(QDropEvent* event);
+    void dropEvent(QDropEvent* event) override;
     void loadExtensions();
 
     void setComparisonMode(const int& mode);

--- a/QtProject/app/videodiscovery.cpp
+++ b/QtProject/app/videodiscovery.cpp
@@ -1,0 +1,79 @@
+#include "videodiscovery.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFileInfo>
+
+namespace
+{
+// Photos keeps a derivative and a thumbnail for every asset, so a real library holds hundreds of thousands of files
+// under resources/ while only originals/ can hold a video worth reviewing: Video::internalProcess rejects anything
+// outside originals/ as a derivative. Enumerating the rest froze the UI for around 25s on a 440k entry library and
+// every one of those entries was then discarded, so the whole library is replaced by its originals/ folder.
+// A library without originals/ holds nothing we would accept, hence an empty result rather than a full walk.
+QStringList directoriesToScanFor(const QDir& dir)
+{
+    if (!dir.dirName().endsWith(QStringLiteral(".photoslibrary")))
+        return {dir.path()};
+
+    const QString originals = dir.filePath(QStringLiteral("originals"));
+    if (!QFileInfo(originals).isDir())
+        return {};
+    return {originals};
+}
+} // namespace
+
+VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& nameFilters,
+                                    const VideoDiscoveryProgress& reportProgress)
+{
+    VideoDiscoveryResult result;
+    QStringList remainingDirectories;
+
+    for (QString directoryPath : directories) {
+        directoryPath.remove(QStringLiteral("\""));
+        if (directoryPath.trimmed().isEmpty())
+            continue;
+        const QDir directory(directoryPath);
+        if (!directory.exists()) {
+            result.missingDirectories.append(QDir::toNativeSeparators(directory.path()));
+            continue;
+        }
+        remainingDirectories.append(directoriesToScanFor(directory));
+    }
+
+    QDir directory;
+    directory.setNameFilters(nameFilters);
+    // Sorting each folder would only cost time: results go into a set and processVideos sorts the final list.
+    directory.setSorting(QDir::Unsorted);
+    // AllDirs lets video globs still see every folder; Files keeps the globs on video names.
+    directory.setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
+
+    while (!remainingDirectories.isEmpty()) {
+        directory.setPath(remainingDirectories.takeLast());
+        if (reportProgress && !reportProgress(result.videos.size(), directory.path())) {
+            result.cancelled = true;
+            return result;
+        }
+
+        // One pass per folder. Subdirectories is omitted so a .photoslibrary can be replaced by originals/ instead
+        // of walking resources/. Symlinked folders are left alone, which also prevents recursion cycles.
+        QDirIterator iter(directory);
+        while (iter.hasNext()) {
+            const QFileInfo entry = iter.nextFileInfo();
+            if (entry.isDir()) {
+                if (!entry.isSymLink())
+                    remainingDirectories.append(directoriesToScanFor(QDir(entry.filePath())));
+                continue;
+            }
+
+            const QString filePathName = entry.canonicalFilePath();
+            result.videos.insert(filePathName);
+            if (reportProgress && !reportProgress(result.videos.size(), filePathName)) {
+                result.cancelled = true;
+                return result;
+            }
+        }
+    }
+
+    return result;
+}

--- a/QtProject/app/videodiscovery.cpp
+++ b/QtProject/app/videodiscovery.cpp
@@ -2,7 +2,10 @@
 
 #include <QDir>
 #include <QDirIterator>
+#include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
+#include <QTextStream>
 
 namespace
 {
@@ -40,6 +43,24 @@ QSet<QString> videoSuffixesFrom(const QStringList& extensionFilters)
     return suffixes;
 }
 } // namespace
+
+QStringList loadVideoExtensionFilters()
+{
+    QFile file(QStringLiteral(":/extensions.ini"));
+    if (!file.open(QIODevice::ReadOnly))
+        return {};
+
+    QStringList filters;
+    QTextStream text(&file);
+    while (!text.atEnd()) {
+        QString line = text.readLine();
+        if (line.startsWith(u';') || line.isEmpty())
+            continue;
+        filters.append(line.replace(QRegularExpression(QStringLiteral("\\*?\\.")), QStringLiteral("*."))
+                           .split(u' ', Qt::SkipEmptyParts));
+    }
+    return filters;
+}
 
 VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& extensionFilters,
                                     const VideoDiscoveryProgress& reportProgress)

--- a/QtProject/app/videodiscovery.cpp
+++ b/QtProject/app/videodiscovery.cpp
@@ -92,8 +92,9 @@ VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStrin
 
         // One pass per folder. Subdirectories is omitted so a .photoslibrary can be replaced by originals/ instead
         // of walking resources/. Symlinked folders are left alone, which also prevents recursion cycles.
-        // Hidden entries stay excluded, as they were when QDir applied the filters.
-        QDirIterator iter(folder, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+        // Hidden entries are included, matching master’s default QDir::AllEntries walk, so hidden videos are found and
+        // Stop is observable on hidden non-video entries too.
+        QDirIterator iter(folder, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot | QDir::Hidden);
         while (iter.hasNext()) {
             const QFileInfo entry = iter.nextFileInfo();
             const bool isDirectory = entry.isDir();

--- a/QtProject/app/videodiscovery.cpp
+++ b/QtProject/app/videodiscovery.cpp
@@ -21,9 +21,27 @@ QStringList directoriesToScanFor(const QDir& dir)
         return {};
     return {originals};
 }
+
+// extensions.ini holds plain extension globs that MainWindow::loadExtensions normalizes to "*.ext", so a suffix set
+// carries the same meaning as handing those globs to QDirIterator. Matching them here instead is what lets the walk
+// observe cancellation on every entry: QDirIterator applies name filters inside hasNext(), so a folder holding many
+// non-video files would otherwise be skipped past inside one call that no Stop request can interrupt. It also replaces
+// one wildcard match per filter per file, over forty of them, with a single hash lookup, and makes matching
+// case-insensitive everywhere rather than only where the filesystem happens to be.
+QSet<QString> videoSuffixesFrom(const QStringList& extensionFilters)
+{
+    QSet<QString> suffixes;
+    for (const QString& filter : extensionFilters) {
+        const QString suffix = filter.mid(filter.lastIndexOf(u'.') + 1).toLower();
+        // An empty suffix would match every extensionless file, so a malformed filter drops out instead.
+        if (!suffix.isEmpty())
+            suffixes.insert(suffix);
+    }
+    return suffixes;
+}
 } // namespace
 
-VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& nameFilters,
+VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& extensionFilters,
                                     const VideoDiscoveryProgress& reportProgress)
 {
     VideoDiscoveryResult result;
@@ -41,34 +59,36 @@ VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStrin
         remainingDirectories.append(directoriesToScanFor(directory));
     }
 
-    QDir directory;
-    directory.setNameFilters(nameFilters);
-    // Sorting each folder would only cost time: results go into a set and processVideos sorts the final list.
-    directory.setSorting(QDir::Unsorted);
-    // AllDirs lets video globs still see every folder; Files keeps the globs on video names.
-    directory.setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot);
+    const QSet<QString> videoSuffixes = videoSuffixesFrom(extensionFilters);
 
     while (!remainingDirectories.isEmpty()) {
-        directory.setPath(remainingDirectories.takeLast());
-        if (reportProgress && !reportProgress(result.videos.size(), directory.path())) {
+        const QString folder = remainingDirectories.takeLast();
+        // Reported before the folder is opened so an empty or unreadable folder still answers a Stop request.
+        if (reportProgress && !reportProgress(result.videos.size(), folder)) {
             result.cancelled = true;
             return result;
         }
 
         // One pass per folder. Subdirectories is omitted so a .photoslibrary can be replaced by originals/ instead
         // of walking resources/. Symlinked folders are left alone, which also prevents recursion cycles.
-        QDirIterator iter(directory);
+        // Hidden entries stay excluded, as they were when QDir applied the filters.
+        QDirIterator iter(folder, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
         while (iter.hasNext()) {
             const QFileInfo entry = iter.nextFileInfo();
-            if (entry.isDir()) {
-                if (!entry.isSymLink())
-                    remainingDirectories.append(directoriesToScanFor(QDir(entry.filePath())));
-                continue;
-            }
+            const bool isDirectory = entry.isDir();
+            const bool isVideo = !isDirectory && videoSuffixes.contains(entry.suffix().toLower());
 
-            const QString filePathName = entry.canonicalFilePath();
-            result.videos.insert(filePathName);
-            if (reportProgress && !reportProgress(result.videos.size(), filePathName)) {
+            QString reportedPath = folder;
+            if (isVideo) {
+                reportedPath = entry.canonicalFilePath();
+                result.videos.insert(reportedPath);
+            }
+            else if (isDirectory && !entry.isSymLink())
+                remainingDirectories.append(directoriesToScanFor(QDir(entry.filePath())));
+
+            // Every entry is reported, videos and skipped files alike, so a folder full of non-video files cannot
+            // hold off a Stop request until its enumeration ends.
+            if (reportProgress && !reportProgress(result.videos.size(), reportedPath)) {
                 result.cancelled = true;
                 return result;
             }

--- a/QtProject/app/videodiscovery.h
+++ b/QtProject/app/videodiscovery.h
@@ -1,0 +1,20 @@
+#ifndef VIDEODISCOVERY_H
+#define VIDEODISCOVERY_H
+
+#include <QSet>
+#include <QStringList>
+
+#include <functional>
+
+struct VideoDiscoveryResult {
+    QSet<QString> videos;
+    QStringList missingDirectories;
+    bool cancelled = false;
+};
+
+using VideoDiscoveryProgress = std::function<bool(int videoCount, const QString& path)>;
+
+VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& nameFilters,
+                                    const VideoDiscoveryProgress& reportProgress = {});
+
+#endif // VIDEODISCOVERY_H

--- a/QtProject/app/videodiscovery.h
+++ b/QtProject/app/videodiscovery.h
@@ -14,7 +14,9 @@ struct VideoDiscoveryResult {
 
 using VideoDiscoveryProgress = std::function<bool(int videoCount, const QString& path)>;
 
-VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& nameFilters,
+// extensionFilters holds the "*.ext" globs from extensions.ini; only the extension part is significant and it is
+// matched case-insensitively. reportProgress is called for every entry seen and stops the walk when it returns false.
+VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& extensionFilters,
                                     const VideoDiscoveryProgress& reportProgress = {});
 
 #endif // VIDEODISCOVERY_H

--- a/QtProject/app/videodiscovery.h
+++ b/QtProject/app/videodiscovery.h
@@ -14,6 +14,10 @@ struct VideoDiscoveryResult {
 
 using VideoDiscoveryProgress = std::function<bool(int videoCount, const QString& path)>;
 
+// Loads the "*.ext" filters bundled in extensions.ini. Keeping parsing beside discovery gives the app and corpus
+// tests one definition of which files are videos.
+QStringList loadVideoExtensionFilters();
+
 // extensionFilters holds the "*.ext" globs from extensions.ini; only the extension part is significant and it is
 // matched case-insensitively. reportProgress is called for every entry seen and stops the walk when it returns false.
 VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStringList& extensionFilters,

--- a/QtProject/tests/CMakeLists.txt
+++ b/QtProject/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ add_qt_test(test_comparison
     SOURCES test_comparison/tst_test_comparison.cpp
 )
 
-# test_mainwindow (currently empty but structure is there)
+# Test 2: directory discovery and MainWindow async integration
 add_qt_test(test_mainwindow
     SOURCES test_mainwindow/tst_mainwindow.cpp
 )

--- a/QtProject/tests/CMakeLists.txt
+++ b/QtProject/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(COMMON_APP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../app/comparison/internal/ssim.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../app/mainwindow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../app/prefs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../app/videodiscovery.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../app/files.qrc
 )
 

--- a/QtProject/tests/external/utils/video_corpus_test_helpers.cpp
+++ b/QtProject/tests/external/utils/video_corpus_test_helpers.cpp
@@ -5,6 +5,7 @@
 #include "../../../app/db.h"
 #include "../../../app/mainwindow.h"
 #include "../../../app/video.h"
+#include "../../../app/videodiscovery.h"
 #include "shared/video_extraction_test_helpers.h"
 
 #include <QCoreApplication>
@@ -205,8 +206,7 @@ void VideoCorpusTestHelpers::runWholeAppScan(const QDir& videoDir, const WholeAp
     if (expectation.cacheOption != Prefs::NO_CACHE) {
         MainWindow warmup;
         warmup.ui->radio_UseCacheYes->click();
-        QDir warmupDir = videoDir;
-        warmup.findVideos(warmupDir);
+        warmup._everyVideo = discoverVideos({videoDir.path()}, warmup._extensionList).videos;
         warmup.processVideos();
         warmup.close();
         QCoreApplication::processEvents();
@@ -230,8 +230,7 @@ void VideoCorpusTestHelpers::runWholeAppScan(const QDir& videoDir, const WholeAp
 
     QElapsedTimer timer;
     timer.start();
-    QDir scanDir = videoDir;
-    window.findVideos(scanDir);
+    window._everyVideo = discoverVideos({videoDir.path()}, window._extensionList).videos;
     window.processVideos();
     Comparison comparison(window._videoList, window._prefs, window.geometry());
     const int matchingVideos = comparison.reportMatchingVideos();

--- a/QtProject/tests/repo/auto_delete/tst_auto_delete.cpp
+++ b/QtProject/tests/repo/auto_delete/tst_auto_delete.cpp
@@ -15,6 +15,7 @@
 #include "../../../app/mainwindow.h"
 #include "../../../app/prefs.h"
 #include "../../../app/ui_mainwindow.h"
+#include "../../../app/videodiscovery.h"
 
 class TestAutoDelete : public QObject
 {
@@ -168,8 +169,7 @@ void TestAutoDelete::test_matchingFeaturePairs()
     w._prefs.useCacheOption(Prefs::NO_CACHE);
     w.on_thresholdSlider_valueChanged(90);
     w.ui->detectRotatedCopiesCheckbox->setChecked(detectRotatedCopies);
-    QDir videoDir(testVideosDir.path());
-    w.findVideos(videoDir);
+    w._everyVideo = discoverVideos({testVideosDir.path()}, w._extensionList).videos;
     w.processVideos();
 
     QCOMPARE(w._everyVideo.count(), 2);
@@ -217,8 +217,7 @@ void TestAutoDelete::test_keepBiggestMovesLetterboxedCopy()
     w._prefs.delMode = Prefs::CUSTOM_TRASH;
     w._prefs.customTrashFolder(QDir(trashDir.path()));
     w.on_thresholdSlider_valueChanged(90);
-    QDir videoDir(testVideosDir.path());
-    w.findVideos(videoDir);
+    w._everyVideo = discoverVideos({testVideosDir.path()}, w._extensionList).videos;
     w.processVideos();
 
     QCOMPARE(w._everyVideo.count(), 2);
@@ -277,8 +276,7 @@ void TestAutoDelete::runAutoDeleteBySize(const bool keepBiggest) const
     w._prefs.customTrashFolder(QDir(trashDir.path()));
     w.on_thresholdSlider_valueChanged(100);
 
-    QDir videoDir(testVideosDir.path());
-    w.findVideos(videoDir);
+    w._everyVideo = discoverVideos({testVideosDir.path()}, w._extensionList).videos;
     w.processVideos();
 
     QCOMPARE(w._everyVideo.count(), 2);

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -1,31 +1,91 @@
-#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
 #include <QtTest>
 
-// add necessary includes here
+#include <memory>
 
+#include "../../app/mainwindow.h"
+
+// Discovery only looks at file names, so empty placeholder files describe a Photos library layout faithfully
+// enough here and keep the fixture out of the repository.
 class TestMainWindow : public QObject
 {
     Q_OBJECT
 
-  public:
-    TestMainWindow();
-    ~TestMainWindow();
-
   private slots:
-    void initTestCase();
-    void cleanupTestCase();
-    void test_case1();
+    void init();
+    void test_photosLibraryInsideScannedFolderOnlyYieldsOriginals();
+    void test_photosLibrarySelectedDirectlyOnlyYieldsOriginals();
+
+  private:
+    std::unique_ptr<QTemporaryDir> _scanRoot;
+
+    QString libraryPath() const;
+    QString createFile(const QString& relativePath) const;
+    QSet<QString> discoveredVideosIn(const QString& directoryPath) const;
 };
 
-TestMainWindow::TestMainWindow() {}
+void TestMainWindow::init()
+{
+    qSetMessagePattern("%{file}(%{line}) %{function}: %{message}");
+    // A fresh tree per test function, so files staged by one case cannot show up in another.
+    _scanRoot = std::make_unique<QTemporaryDir>();
+    QVERIFY(_scanRoot->isValid());
+}
 
-TestMainWindow::~TestMainWindow() {}
+QString TestMainWindow::libraryPath() const
+{
+    return QDir(_scanRoot->path()).filePath(QStringLiteral("Photos Library.photoslibrary"));
+}
 
-void TestMainWindow::initTestCase() {}
+QString TestMainWindow::createFile(const QString& relativePath) const
+{
+    const QString absolutePath = QDir(_scanRoot->path()).filePath(relativePath);
+    if (!QDir().mkpath(QFileInfo(absolutePath).absolutePath()))
+        return {};
+    QFile file(absolutePath);
+    if (!file.open(QIODevice::WriteOnly))
+        return {};
+    file.close();
+    return QFileInfo(absolutePath).canonicalFilePath();
+}
 
-void TestMainWindow::cleanupTestCase() {}
+QSet<QString> TestMainWindow::discoveredVideosIn(const QString& directoryPath) const
+{
+    MainWindow window;
+    window.loadExtensions();
+    QDir directory(directoryPath);
+    window.findVideos(directory);
+    window.close();
+    return window._everyVideo;
+}
 
-void TestMainWindow::test_case1() {}
+void TestMainWindow::test_photosLibraryInsideScannedFolderOnlyYieldsOriginals()
+{
+    const QString originalVideo = createFile(QStringLiteral("Photos Library.photoslibrary/originals/4/kept.mov"));
+    const QString plainVideo = createFile(QStringLiteral("Movies/holiday.mp4"));
+    QVERIFY(!originalVideo.isEmpty());
+    QVERIFY(!plainVideo.isEmpty());
+    // resources/ is where a real library keeps its hundreds of thousands of derivatives and thumbnails.
+    QVERIFY(
+        !createFile(QStringLiteral("Photos Library.photoslibrary/resources/derivatives/4/kept_1_105_c.mov")).isEmpty());
+    QVERIFY(!createFile(QStringLiteral("Photos Library.photoslibrary/private/com.apple.Photos/cached.mp4")).isEmpty());
+    // A library with no originals/ holds nothing the scan would accept, so none of it should be walked either.
+    QVERIFY(!createFile(QStringLiteral("Empty Library.photoslibrary/resources/derivatives/orphan.mov")).isEmpty());
+
+    QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({originalVideo, plainVideo}));
+}
+
+void TestMainWindow::test_photosLibrarySelectedDirectlyOnlyYieldsOriginals()
+{
+    // The Apple Photos browse button puts the .photoslibrary bundle itself in the scan list.
+    const QString originalVideo = createFile(QStringLiteral("Photos Library.photoslibrary/originals/1/kept.mp4"));
+    QVERIFY(!originalVideo.isEmpty());
+    QVERIFY(!createFile(QStringLiteral("Photos Library.photoslibrary/resources/renders/kept_rendered.mp4")).isEmpty());
+
+    QCOMPARE(discoveredVideosIn(libraryPath()), QSet<QString>({originalVideo}));
+}
 
 QTEST_MAIN(TestMainWindow)
 

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -25,6 +25,7 @@ class TestMainWindow : public QObject
     void test_discoveryCanBeCancelled();
     void test_discoveryCanBeCancelledWhileSkippingNonVideos();
     void test_videoExtensionsMatchRegardlessOfCase();
+    void test_hiddenEntriesAreDiscovered();
     void test_loadVideoExtensionFilters();
     void test_emptyFolderScanLeavesNoSearchingMessage();
 
@@ -134,6 +135,18 @@ void TestMainWindow::test_videoExtensionsMatchRegardlessOfCase()
     QVERIFY(!createFile(QStringLiteral("Movies/notes.TXT")).isEmpty());
 
     QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({shouting, mixed}));
+}
+
+void TestMainWindow::test_hiddenEntriesAreDiscovered()
+{
+    const QString inHiddenDir = createFile(QStringLiteral(".private/cache/video.mp4"));
+    const QString hiddenFile = createFile(QStringLiteral("Movies/.hidden.mov"));
+    const QString normal = createFile(QStringLiteral("Movies/normal.mp4"));
+    QVERIFY(!inHiddenDir.isEmpty());
+    QVERIFY(!hiddenFile.isEmpty());
+    QVERIFY(!normal.isEmpty());
+
+    QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({inHiddenDir, hiddenFile, normal}));
 }
 
 void TestMainWindow::test_loadVideoExtensionFilters()

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -5,6 +5,9 @@
 
 #include <memory>
 
+#include "../../app/mainwindow.h"
+#include "../../app/prefs.h"
+#include "../../app/ui_mainwindow.h"
 #include "../../app/videodiscovery.h"
 
 // Discovery only looks at file names, so empty placeholder files describe a Photos library layout faithfully
@@ -18,6 +21,9 @@ class TestMainWindow : public QObject
     void test_photosLibraryInsideScannedFolderOnlyYieldsOriginals();
     void test_photosLibrarySelectedDirectlyOnlyYieldsOriginals();
     void test_discoveryCanBeCancelled();
+    void test_discoveryCanBeCancelledWhileSkippingNonVideos();
+    void test_videoExtensionsMatchRegardlessOfCase();
+    void test_emptyFolderScanLeavesNoSearchingMessage();
 
   private:
     std::unique_ptr<QTemporaryDir> _scanRoot;
@@ -97,6 +103,62 @@ void TestMainWindow::test_discoveryCanBeCancelled()
 
     QVERIFY(result.cancelled);
     QVERIFY(result.videos.isEmpty());
+}
+
+// A folder can hold far more non-video files than videos, and skipping those must not delay a Stop request: name
+// filters handed to QDirIterator would be applied inside hasNext(), hiding the whole enumeration behind one call.
+void TestMainWindow::test_discoveryCanBeCancelledWhileSkippingNonVideos()
+{
+    QVERIFY(!createFile(QStringLiteral("Movies/first.mp4")).isEmpty());
+    for (int index = 0; index < 50; index++)
+        QVERIFY(!createFile(QStringLiteral("Movies/note%1.txt").arg(index)).isEmpty());
+
+    int reportedEntries = 0;
+    const VideoDiscoveryResult result =
+        discoverVideos({_scanRoot->path()}, {QStringLiteral("*.mp4")}, [&reportedEntries](int, const QString&) {
+            reportedEntries++;
+            // Cancel partway through the folder, once enumeration is under way but well before the last entry.
+            return reportedEntries < 10;
+        });
+
+    QVERIFY(result.cancelled);
+    QCOMPARE(reportedEntries, 10);
+}
+
+void TestMainWindow::test_videoExtensionsMatchRegardlessOfCase()
+{
+    const QString shouting = createFile(QStringLiteral("Movies/HOLIDAY.MP4"));
+    const QString mixed = createFile(QStringLiteral("Movies/Trip.Mov"));
+    QVERIFY(!shouting.isEmpty());
+    QVERIFY(!mixed.isEmpty());
+    QVERIFY(!createFile(QStringLiteral("Movies/notes.TXT")).isEmpty());
+
+    QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({shouting, mixed}));
+}
+
+// Discovery runs on a worker thread, so the window has to settle back to an idle state on its own. A folder with no
+// videos is the path that skips processing entirely, which is exactly where a leftover progress message would show up.
+void TestMainWindow::test_emptyFolderScanLeavesNoSearchingMessage()
+{
+    QVERIFY(!createFile(QStringLiteral("Documents/notes.txt")).isEmpty());
+
+    MainWindow window;
+    window.show();
+    window._prefs.useCacheOption(Prefs::NO_CACHE);
+    window.ui->directoryBox->setText(QDir(_scanRoot->path()).filePath(QStringLiteral("Documents")));
+
+    QSignalSpy discoveryFinished(&window._videoDiscoveryWatcher, &QFutureWatcherBase::finished);
+    window.on_findDuplicates_clicked();
+    QVERIFY(discoveryFinished.wait(30000));
+    QCoreApplication::processEvents();
+
+    QVERIFY(window._everyVideo.isEmpty());
+    QCOMPARE(window.ui->statusBar->currentMessage(), QString());
+    QCOMPARE(window.ui->findDuplicates->text(), QStringLiteral("Find duplicates"));
+    QVERIFY(window.ui->directoryBox->isEnabled());
+
+    window.close();
+    QCoreApplication::processEvents();
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-#include "../../app/mainwindow.h"
+#include "../../app/videodiscovery.h"
 
 // Discovery only looks at file names, so empty placeholder files describe a Photos library layout faithfully
 // enough here and keep the fixture out of the repository.
@@ -17,6 +17,7 @@ class TestMainWindow : public QObject
     void init();
     void test_photosLibraryInsideScannedFolderOnlyYieldsOriginals();
     void test_photosLibrarySelectedDirectlyOnlyYieldsOriginals();
+    void test_discoveryCanBeCancelled();
 
   private:
     std::unique_ptr<QTemporaryDir> _scanRoot;
@@ -53,12 +54,7 @@ QString TestMainWindow::createFile(const QString& relativePath) const
 
 QSet<QString> TestMainWindow::discoveredVideosIn(const QString& directoryPath) const
 {
-    MainWindow window;
-    window.loadExtensions();
-    QDir directory(directoryPath);
-    window.findVideos(directory);
-    window.close();
-    return window._everyVideo;
+    return discoverVideos({directoryPath}, {QStringLiteral("*.mp4"), QStringLiteral("*.mov")}).videos;
 }
 
 void TestMainWindow::test_photosLibraryInsideScannedFolderOnlyYieldsOriginals()
@@ -85,6 +81,22 @@ void TestMainWindow::test_photosLibrarySelectedDirectlyOnlyYieldsOriginals()
     QVERIFY(!createFile(QStringLiteral("Photos Library.photoslibrary/resources/renders/kept_rendered.mp4")).isEmpty());
 
     QCOMPARE(discoveredVideosIn(libraryPath()), QSet<QString>({originalVideo}));
+}
+
+void TestMainWindow::test_discoveryCanBeCancelled()
+{
+    const QString firstVideo = createFile(QStringLiteral("Movies/first.mp4"));
+    QVERIFY(!firstVideo.isEmpty());
+    QVERIFY(!createFile(QStringLiteral("Movies/second.mp4")).isEmpty());
+
+    const VideoDiscoveryResult result =
+        discoverVideos({_scanRoot->path()}, {QStringLiteral("*.mp4")},
+                       [](int, const QString&) {
+                           return false;
+                       });
+
+    QVERIFY(result.cancelled);
+    QVERIFY(result.videos.isEmpty());
 }
 
 QTEST_MAIN(TestMainWindow)

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -1,13 +1,15 @@
 #include <QDir>
 #include <QFile>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QStatusBar>
 #include <QTemporaryDir>
 #include <QtTest>
 
 #include <memory>
 
 #include "../../app/mainwindow.h"
-#include "../../app/prefs.h"
-#include "../../app/ui_mainwindow.h"
 #include "../../app/videodiscovery.h"
 
 // Discovery only looks at file names, so empty placeholder files describe a Photos library layout faithfully
@@ -23,6 +25,7 @@ class TestMainWindow : public QObject
     void test_discoveryCanBeCancelled();
     void test_discoveryCanBeCancelledWhileSkippingNonVideos();
     void test_videoExtensionsMatchRegardlessOfCase();
+    void test_loadVideoExtensionFilters();
     void test_emptyFolderScanLeavesNoSearchingMessage();
 
   private:
@@ -96,10 +99,7 @@ void TestMainWindow::test_discoveryCanBeCancelled()
     QVERIFY(!createFile(QStringLiteral("Movies/second.mp4")).isEmpty());
 
     const VideoDiscoveryResult result =
-        discoverVideos({_scanRoot->path()}, {QStringLiteral("*.mp4")},
-                       [](int, const QString&) {
-                           return false;
-                       });
+        discoverVideos({_scanRoot->path()}, {QStringLiteral("*.mp4")}, [](int, const QString&) { return false; });
 
     QVERIFY(result.cancelled);
     QVERIFY(result.videos.isEmpty());
@@ -136,6 +136,14 @@ void TestMainWindow::test_videoExtensionsMatchRegardlessOfCase()
     QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({shouting, mixed}));
 }
 
+void TestMainWindow::test_loadVideoExtensionFilters()
+{
+    const QStringList filters = loadVideoExtensionFilters();
+    QVERIFY(filters.contains(QStringLiteral("*.mp4")));
+    QVERIFY(filters.contains(QStringLiteral("*.mov")));
+    QVERIFY(!filters.contains(QString()));
+}
+
 // Discovery runs on a worker thread, so the window has to settle back to an idle state on its own. A folder with no
 // videos is the path that skips processing entirely, which is exactly where a leftover progress message would show up.
 void TestMainWindow::test_emptyFolderScanLeavesNoSearchingMessage()
@@ -144,18 +152,22 @@ void TestMainWindow::test_emptyFolderScanLeavesNoSearchingMessage()
 
     MainWindow window;
     window.show();
-    window._prefs.useCacheOption(Prefs::NO_CACHE);
-    window.ui->directoryBox->setText(QDir(_scanRoot->path()).filePath(QStringLiteral("Documents")));
+    auto* noCache = window.findChild<QRadioButton*>(QStringLiteral("radio_UseCacheNo"));
+    auto* directoryBox = window.findChild<QLineEdit*>(QStringLiteral("directoryBox"));
+    auto* findDuplicates = window.findChild<QPushButton*>(QStringLiteral("findDuplicates"));
+    auto* statusBar = window.findChild<QStatusBar*>(QStringLiteral("statusBar"));
+    QVERIFY(noCache);
+    QVERIFY(directoryBox);
+    QVERIFY(findDuplicates);
+    QVERIFY(statusBar);
 
-    QSignalSpy discoveryFinished(&window._videoDiscoveryWatcher, &QFutureWatcherBase::finished);
-    window.on_findDuplicates_clicked();
-    QVERIFY(discoveryFinished.wait(30000));
-    QCoreApplication::processEvents();
+    noCache->click();
+    directoryBox->setText(QDir(_scanRoot->path()).filePath(QStringLiteral("Documents")));
+    findDuplicates->click();
+    QTRY_COMPARE_WITH_TIMEOUT(findDuplicates->text(), QStringLiteral("Find duplicates"), 30000);
 
-    QVERIFY(window._everyVideo.isEmpty());
-    QCOMPARE(window.ui->statusBar->currentMessage(), QString());
-    QCOMPARE(window.ui->findDuplicates->text(), QStringLiteral("Find duplicates"));
-    QVERIFY(window.ui->directoryBox->isEnabled());
+    QCOMPARE(statusBar->currentMessage(), QString());
+    QVERIFY(directoryBox->isEnabled());
 
     window.close();
     QCoreApplication::processEvents();


### PR DESCRIPTION
## Summary
- Move filesystem discovery to `QtConcurrent` so dense folders cannot block the UI thread, while preserving Stop and processing videos found before cancellation.
- Throttle bottom status-bar progress to 10 Hz instead of calling `processEvents()` and refreshing widgets for every discovered video.
- Avoid the known worst case by pruning Apple Photos bundles to `originals/`; `resources/` contains hundreds of thousands of derivatives that `Video::internalProcess` rejects anyway.
- Keep discovery independently testable, including nested/direct Photos libraries and cancellation.

## Performance
- Real Photos library (~439k entries): ~25s before; ~8ms after pruning.
- Generic dense folders may still take time to enumerate, but discovery now runs off the UI thread and reports throttled progress.
- Local Qt UI benchmark (10k updates): status + `processEvents()` per item took ~318ms versus negligible widget calls without pumping the event loop.

## Test plan
- [x] Build `video-simili-duplicate-cleaner` and `test_mainwindow`
- [x] `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R \"^(test_comparison|test_mainwindow|test_repo_auto_delete|test_repo_video_matching)$\"`
- [ ] Manually scan a generic folder containing many non-video files and confirm the window remains responsive
- [ ] Select a `.photoslibrary` directly, confirm only originals are found, then rescan