### PR TITLE
refactor(cache): cache all processing failures and file timestamps

### DIFF
--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -121,10 +121,14 @@ void Db::createTables(QSqlDatabase db, const QString appVersion)
                               "width INTEGER, "
                               "height INTEGER, "
                               "additional_metadata TEXT, "
-                              "failure TEXT"
+                              "failure TEXT, "
+                              "modified TEXT, "
+                              "birth_time TEXT"
                               ");"));
-    // Existing caches created before failure lived on this row; duplicate-column errors are ignored.
+    // Existing caches created before these columns existed; duplicate-column errors are ignored.
     query.exec(QStringLiteral("ALTER TABLE metadata ADD COLUMN failure TEXT"));
+    query.exec(QStringLiteral("ALTER TABLE metadata ADD COLUMN modified TEXT"));
+    query.exec(QStringLiteral("ALTER TABLE metadata ADD COLUMN birth_time TEXT"));
 
     query.exec(QStringLiteral("CREATE TABLE IF NOT EXISTS "
                               "capture ("
@@ -191,6 +195,11 @@ Db::~Db()
     QSqlDatabase::removeDatabase(_uniqueConnexionName); // clear the connexion backlog, basically... !
 }
 
+namespace
+{
+const QString metadataDateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+} // namespace
+
 bool Db::readMetadata(Video& video) const
 {
     if (!_db.isOpen()) {
@@ -208,17 +217,16 @@ bool Db::readMetadata(Video& video) const
     }
 
     while (query.next()) {
-        //        video.modified = _modified;
-        video.size = query.value(1).toLongLong();
-        video.duration = query.value(2).toLongLong();
-        video.bitrate = query.value(3).toInt();
-        video.framerate = query.value(4).toDouble();
-        video.codec = query.value(5).toString();
-        video.audio = query.value(6).toString();
-        video.width = static_cast<short>(query.value(7).toInt());
-        video.height = static_cast<short>(query.value(8).toInt());
+        video.size = query.value(QStringLiteral("size")).toLongLong();
+        video.duration = query.value(QStringLiteral("duration")).toLongLong();
+        video.bitrate = query.value(QStringLiteral("bitrate")).toInt();
+        video.framerate = query.value(QStringLiteral("framerate")).toDouble();
+        video.codec = query.value(QStringLiteral("codec")).toString();
+        video.audio = query.value(QStringLiteral("audio")).toString();
+        video.width = static_cast<short>(query.value(QStringLiteral("width")).toInt());
+        video.height = static_cast<short>(query.value(QStringLiteral("height")).toInt());
 
-        QString jsonString = query.value(9).toString();
+        QString jsonString = query.value(QStringLiteral("additional_metadata")).toString();
         QMap<QString, QString> map;
         if (!jsonString.isEmpty()) {
             QJsonDocument doc = QJsonDocument::fromJson(jsonString.toUtf8());
@@ -229,6 +237,10 @@ bool Db::readMetadata(Video& video) const
         video.meta.additionalMetadata = map;
         video.meta.setRelevantValuesFromAdditionalMetadata();
         video.cachedFailure = query.value(QStringLiteral("failure")).toString();
+        video.modified =
+            QDateTime::fromString(query.value(QStringLiteral("modified")).toString(), metadataDateTimeFormat);
+        video._fileCreateDate =
+            QDateTime::fromString(query.value(QStringLiteral("birth_time")).toString(), metadataDateTimeFormat);
         return true;
     } // TODO : should proooobably delete others if there are multiple results !!! Or produce error !
     return false;
@@ -242,9 +254,12 @@ void Db::writeMetadata(const Video& video) const
     }
 
     QSqlQuery query(_db);
-    query.prepare("INSERT OR REPLACE INTO metadata "
-                  "(id, size, duration, bitrate, framerate, codec, audio, width, height, additional_metadata, failure) "
-                  "VALUES(:id,:size,:duration,:bitrate,:framerate,:codec,:audio,:width,:height,:additional_metadata,:failure);");
+    query.prepare(
+        "INSERT OR REPLACE INTO metadata "
+        "(id, size, duration, bitrate, framerate, codec, audio, width, height, additional_metadata, failure, modified, "
+        "birth_time) "
+        "VALUES(:id,:size,:duration,:bitrate,:framerate,:codec,:audio,:width,:height,:additional_metadata,:failure,"
+        ":modified,:birth_time);");
     query.bindValue(":id", video._filePathName);
     query.bindValue(":size", QVariant::fromValue(static_cast<qlonglong>(video.size)));
     query.bindValue(":duration", QVariant::fromValue(static_cast<qlonglong>(video.duration)));
@@ -261,6 +276,11 @@ void Db::writeMetadata(const Video& video) const
     QString jsonString = QJsonDocument(QJsonObject::fromVariantMap(vmap)).toJson(QJsonDocument::Compact);
     query.bindValue(":additional_metadata", jsonString);
     query.bindValue(":failure", video.cachedFailure);
+    query.bindValue(":modified",
+                    video.modified.isValid() ? video.modified.toString(metadataDateTimeFormat) : QString());
+    query.bindValue(":birth_time", video._fileCreateDate.isValid()
+                                       ? video._fileCreateDate.toString(metadataDateTimeFormat)
+                                       : QString());
     query.exec();
 
     QSqlError error = query.lastError();
@@ -279,9 +299,16 @@ void Db::writeFailure(const QString& filePathname, const QString& failure) const
     }
 
     QSqlQuery query(_db);
-    query.prepare("UPDATE metadata SET failure = :failure WHERE id = :id;");
-    query.bindValue(":failure", failure);
+    query.prepare("DELETE FROM capture WHERE id = :id;");
     query.bindValue(":id", filePathname);
+    query.exec();
+
+    query.prepare("INSERT OR REPLACE INTO metadata "
+                  "(id, size, duration, bitrate, framerate, codec, audio, width, height, additional_metadata, failure, "
+                  "modified, birth_time) "
+                  "VALUES(:id, 0, 0, 0, 0, '', '', 0, 0, '', :failure, '', '');");
+    query.bindValue(":id", filePathname);
+    query.bindValue(":failure", failure);
     query.exec();
 
     QSqlError error = query.lastError();

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -197,17 +197,7 @@ Db::~Db()
 
 namespace
 {
-// ISO-8601 with milliseconds preserves sub-second ordering used by auto-delete comparisons
-// and keeps the original UTC offset from QFileInfo timestamps.
-QString serializeMetadataDateTime(const QDateTime& dateTime)
-{
-    return dateTime.isValid() ? dateTime.toString(Qt::ISODateWithMs) : QString();
-}
-
-QDateTime deserializeMetadataDateTime(const QString& text)
-{
-    return text.isEmpty() ? QDateTime{} : QDateTime::fromString(text, Qt::ISODateWithMs);
-}
+const QString metadataDateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
 } // namespace
 
 bool Db::readMetadata(Video& video) const
@@ -247,8 +237,10 @@ bool Db::readMetadata(Video& video) const
         video.meta.additionalMetadata = map;
         video.meta.setRelevantValuesFromAdditionalMetadata();
         video.cachedFailure = query.value(QStringLiteral("failure")).toString();
-        video.modified = deserializeMetadataDateTime(query.value(QStringLiteral("modified")).toString());
-        video._fileCreateDate = deserializeMetadataDateTime(query.value(QStringLiteral("birth_time")).toString());
+        video.modified =
+            QDateTime::fromString(query.value(QStringLiteral("modified")).toString(), metadataDateTimeFormat);
+        video._fileCreateDate =
+            QDateTime::fromString(query.value(QStringLiteral("birth_time")).toString(), metadataDateTimeFormat);
         return true;
     } // TODO : should proooobably delete others if there are multiple results !!! Or produce error !
     return false;
@@ -284,8 +276,11 @@ void Db::writeMetadata(const Video& video) const
     QString jsonString = QJsonDocument(QJsonObject::fromVariantMap(vmap)).toJson(QJsonDocument::Compact);
     query.bindValue(":additional_metadata", jsonString);
     query.bindValue(":failure", video.cachedFailure);
-    query.bindValue(":modified", serializeMetadataDateTime(video.modified));
-    query.bindValue(":birth_time", serializeMetadataDateTime(video._fileCreateDate));
+    query.bindValue(":modified",
+                    video.modified.isValid() ? video.modified.toString(metadataDateTimeFormat) : QString());
+    query.bindValue(":birth_time", video._fileCreateDate.isValid()
+                                       ? video._fileCreateDate.toString(metadataDateTimeFormat)
+                                       : QString());
     query.exec();
 
     QSqlError error = query.lastError();

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -197,7 +197,24 @@ Db::~Db()
 
 namespace
 {
-const QString metadataDateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+// ISO-8601 with milliseconds preserves sub-second ordering used by auto-delete comparisons
+// and keeps the original UTC offset from QFileInfo timestamps.
+QString serializeMetadataDateTime(const QDateTime& dateTime)
+{
+    return dateTime.isValid() ? dateTime.toString(Qt::ISODateWithMs) : QString();
+}
+
+QDateTime deserializeMetadataDateTime(const QString& text)
+{
+    if (text.isEmpty())
+        return {};
+    QDateTime dateTime = QDateTime::fromString(text, Qt::ISODateWithMs);
+    if (!dateTime.isValid()) {
+        // Rows written by an earlier revision of this PR used second-only local strings.
+        dateTime = QDateTime::fromString(text, QStringLiteral("yyyy-MM-dd HH:mm:ss"));
+    }
+    return dateTime;
+}
 } // namespace
 
 bool Db::readMetadata(Video& video) const
@@ -237,10 +254,8 @@ bool Db::readMetadata(Video& video) const
         video.meta.additionalMetadata = map;
         video.meta.setRelevantValuesFromAdditionalMetadata();
         video.cachedFailure = query.value(QStringLiteral("failure")).toString();
-        video.modified =
-            QDateTime::fromString(query.value(QStringLiteral("modified")).toString(), metadataDateTimeFormat);
-        video._fileCreateDate =
-            QDateTime::fromString(query.value(QStringLiteral("birth_time")).toString(), metadataDateTimeFormat);
+        video.modified = deserializeMetadataDateTime(query.value(QStringLiteral("modified")).toString());
+        video._fileCreateDate = deserializeMetadataDateTime(query.value(QStringLiteral("birth_time")).toString());
         return true;
     } // TODO : should proooobably delete others if there are multiple results !!! Or produce error !
     return false;
@@ -276,11 +291,8 @@ void Db::writeMetadata(const Video& video) const
     QString jsonString = QJsonDocument(QJsonObject::fromVariantMap(vmap)).toJson(QJsonDocument::Compact);
     query.bindValue(":additional_metadata", jsonString);
     query.bindValue(":failure", video.cachedFailure);
-    query.bindValue(":modified",
-                    video.modified.isValid() ? video.modified.toString(metadataDateTimeFormat) : QString());
-    query.bindValue(":birth_time", video._fileCreateDate.isValid()
-                                       ? video._fileCreateDate.toString(metadataDateTimeFormat)
-                                       : QString());
+    query.bindValue(":modified", serializeMetadataDateTime(video.modified));
+    query.bindValue(":birth_time", serializeMetadataDateTime(video._fileCreateDate));
     query.exec();
 
     QSqlError error = query.lastError();

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -206,14 +206,7 @@ QString serializeMetadataDateTime(const QDateTime& dateTime)
 
 QDateTime deserializeMetadataDateTime(const QString& text)
 {
-    if (text.isEmpty())
-        return {};
-    QDateTime dateTime = QDateTime::fromString(text, Qt::ISODateWithMs);
-    if (!dateTime.isValid()) {
-        // Rows written by an earlier revision of this PR used second-only local strings.
-        dateTime = QDateTime::fromString(text, QStringLiteral("yyyy-MM-dd HH:mm:ss"));
-    }
-    return dateTime;
+    return text.isEmpty() ? QDateTime{} : QDateTime::fromString(text, Qt::ISODateWithMs);
 }
 } // namespace
 

--- a/QtProject/app/db.h
+++ b/QtProject/app/db.h
@@ -51,8 +51,7 @@ class Db
     //save video properties in cache, including any cachedFailure from a previous processing attempt
     void writeMetadata(const Video& video) const;
 
-    // Marks an already cached video as failed, leaving its metadata untouched. Does nothing when the video has no
-    // metadata row yet, which only leaves the failure unrecorded so the next scan processes the video again.
+    // Replaces any cached state for this path with a failure-only metadata row (creates the row when missing).
     void writeFailure(const QString& filePathname, const QString& failure) const;
 
     //returns screen capture if it was cached, else return null ptr

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -77,19 +77,32 @@ Video::ProcessingResult Video::process()
     result.success = false;
     result.video = this;
 
-    const auto err = this->internalProcess();
-    if (!err.isEmpty())
-        result.errorMsg = err;
+    if (this->_prefs.isVerbose())
+        Message::Get()->add(QString("[%1] STARTING %2").arg(QTime::currentTime().toString(), this->_filePathName));
+
+    const QString validationError = validateInput();
+    if (!validationError.isEmpty()) {
+        result.errorMsg = validationError;
+        return result;
+    }
+
+    Db cache(_prefs.cacheFilePathName());
+    ProcessingStepResult step = processMetadata(cache);
+    if (step.error.isEmpty())
+        step = processFrames(cache);
+
+    if (!step.error.isEmpty()) {
+        result.errorMsg = step.error;
+        if (step.cacheFailure && _prefs.useCacheOption() == Prefs::WITH_CACHE)
+            cache.writeFailure(_filePathName, step.error);
+    }
     else
         result.success = true;
     return result;
 }
 
-QString Video::internalProcess()
+QString Video::validateInput() const
 {
-    if (this->_prefs.isVerbose())
-        Message::Get()->add(QString("[%1] STARTING %2").arg(QTime::currentTime().toString(), this->_filePathName));
-
     if (!QFileInfo::exists(_filePathName))
         return "file doesn't seem to exist";
 #ifdef Q_OS_MACOS
@@ -101,65 +114,61 @@ QString Video::internalProcess()
             return "video seems to be a live photo, so deal with it as a photo.";
     }
 #endif
+    return "";
+}
 
-    // THEODEBUG : probably should re-implement things not to cache randomly !
-    Db cache(_prefs.cacheFilePathName()); // we open the db here, but we'll only store things if needed
-    if (this->_prefs.useCacheOption() != Prefs::NO_CACHE && cache.readMetadata(*this))
+Video::ProcessingStepResult Video::processMetadata(const Db& cache)
+{
+    if (_prefs.useCacheOption() != Prefs::NO_CACHE && cache.readMetadata(*this))
     { //check first if video properties are cached
         if (!cachedFailure.isEmpty())
-            return QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure);
+            return {QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure)};
         modified = QFileInfo(_filePathName).lastModified(); // Db doesn't cache the modified date
         if (QFileInfo(_filePathName).birthTime().isValid())
             _fileCreateDate = QFileInfo(_filePathName).birthTime();
     }
-    else if (this->_prefs.useCacheOption() != Prefs::CACHE_ONLY) {
+    else if (_prefs.useCacheOption() != Prefs::CACHE_ONLY) {
         if (QFileInfo(_filePathName).size() == 0)
         { // check this before, as it's faster, but getMetadata also does this but stores the info
-            return "file size = 0 ";
+            return {"file size = 0 "};
         }
-        auto err = getMetadata(_filePathName);
+        const auto err = getMetadata(_filePathName);
         if (!err.isEmpty()) { //as not cached, read metadata with ffmpeg
-            return QString("could not read metadata: %1").arg(err);
+            return {QString("could not read metadata: %1").arg(err)};
         }
+        if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
+            cache.writeMetadata(*this);
     }
     else {
-        return "video was not fully cached ";
+        return {"video was not fully cached "};
     }
-    if (this->_prefs.useCacheOption()
-        == Prefs::WITH_CACHE)       // TODO-REFACTOR could we move this into the case when we actually cache data ?
-        cache.writeMetadata(*this); // cache so next run will be faster
-    bool durationWasZero = false;   // we'll update cache again later if duration was 0
-    if (duration == 0)
-        durationWasZero = true;
 
     if (width == 0
         || height == 0) // || duration == 0) // no duration check as we can infer duration when decoding frames,
     {
         const QString error = QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
-        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE)
-            cache.writeFailure(_filePathName, error);
-        return error;
+        return {error, true};
     }
+    return {};
+}
 
-    auto err = takeScreenCaptures(cache);
-    if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE && durationWasZero && duration != 0)
+Video::ProcessingStepResult Video::processFrames(const Db& cache)
+{
+    const bool durationWasZero = duration == 0;
+    const auto err = takeScreenCaptures(cache);
+    if (_prefs.useCacheOption() == Prefs::WITH_CACHE && durationWasZero && duration != 0)
         cache.writeMetadata(*this); // update cache as takeScreenCaptures can estimate duration, when it was 0
     if (!err.isEmpty()) {
         // A capture error can be an unavailable source or temporary resource failure, so let the next scan retry it.
-        return QString("capture failed: %1").arg(err);
+        return {QString("capture failed: %1").arg(err)};
     }
-    else if ((this->_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
+    else if ((_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
              || // only cutEnds separates fingerprints for captures; other modes treat the collage as one fingerprint
-             (this->_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
+             (_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
     { //every extracted frame have almost no features/fully flat (e.g. all black)
-        const QString error = "all extracted frames were blank";
-        if (this->_prefs.useCacheOption() == Prefs::WITH_CACHE)
-            cache.writeFailure(_filePathName, error);
-        return error;
+        return {"all extracted frames were blank", true};
     }
-    else {
-        return "";
-    }
+    return {};
 }
 
 const QString Video::getMetadata(const QString& filename)

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -1,6 +1,7 @@
 #include "video.h"
 
 #include <cmath>
+#include <memory>
 
 #define FAIL_ON_FRAME_DECODE_NB_FAIL 10
 
@@ -80,24 +81,46 @@ Video::ProcessingResult Video::process()
     if (this->_prefs.isVerbose())
         Message::Get()->add(QString("[%1] STARTING %2").arg(QTime::currentTime().toString(), this->_filePathName));
 
+    std::unique_ptr<Db> cache;
+    if (_prefs.useCacheOption() != Prefs::NO_CACHE)
+        cache = std::make_unique<Db>(_prefs.cacheFilePathName());
+
     const QString validationError = validateInput();
     if (!validationError.isEmpty()) {
         result.errorMsg = validationError;
+        if (cache != nullptr)
+            cache->writeFailure(_filePathName, validationError);
         return result;
     }
 
-    Db cache(_prefs.cacheFilePathName());
-    ProcessingStepResult step = processMetadata(cache);
-    if (step.error.isEmpty())
-        step = processFrames(cache);
-
-    if (!step.error.isEmpty()) {
-        result.errorMsg = step.error;
-        if (step.cacheFailure && _prefs.useCacheOption() == Prefs::WITH_CACHE)
-            cache.writeFailure(_filePathName, step.error);
+    const bool metadataCached = cache != nullptr && cache->readMetadata(*this);
+    if (metadataCached && !cachedFailure.isEmpty()) {
+        result.errorMsg =
+            QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure);
+        return result;
     }
-    else
-        result.success = true;
+
+    QString error = processMetadata(metadataCached);
+    if (!error.isEmpty()) {
+        result.errorMsg = error;
+        if (cache != nullptr)
+            cache->writeFailure(_filePathName, error);
+        return result;
+    }
+
+    error = processFrames(cache.get());
+    if (!error.isEmpty()) {
+        result.errorMsg = error;
+        if (cache != nullptr)
+            cache->writeFailure(_filePathName, error);
+        return result;
+    }
+
+    result.success = true;
+    // Cache metadata only after a full successful run: duration may still be 0 after metadata extraction
+    // and get inferred later while decoding frames, so we wait until both stages finish.
+    if (cache != nullptr && !metadataCached)
+        cache->writeMetadata(*this);
     return result;
 }
 
@@ -117,56 +140,39 @@ QString Video::validateInput() const
     return "";
 }
 
-Video::ProcessingStepResult Video::processMetadata(const Db& cache)
+QString Video::processMetadata(const bool metadataCached)
 {
-    if (_prefs.useCacheOption() != Prefs::NO_CACHE && cache.readMetadata(*this))
-    { //check first if video properties are cached
-        if (!cachedFailure.isEmpty())
-            return {QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure)};
-        modified = QFileInfo(_filePathName).lastModified(); // Db doesn't cache the modified date
-        if (QFileInfo(_filePathName).birthTime().isValid())
-            _fileCreateDate = QFileInfo(_filePathName).birthTime();
-    }
-    else if (_prefs.useCacheOption() != Prefs::CACHE_ONLY) {
+    if (!metadataCached) {
+        if (_prefs.useCacheOption() == Prefs::CACHE_ONLY)
+            return QStringLiteral("video was not fully cached ");
         if (QFileInfo(_filePathName).size() == 0)
         { // check this before, as it's faster, but getMetadata also does this but stores the info
-            return {"file size = 0 "};
+            return QStringLiteral("file size = 0 ");
         }
         const auto err = getMetadata(_filePathName);
         if (!err.isEmpty()) { //as not cached, read metadata with ffmpeg
-            return {QString("could not read metadata: %1").arg(err)};
+            return QString("could not read metadata: %1").arg(err);
         }
-        if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
-            cache.writeMetadata(*this);
-    }
-    else {
-        return {"video was not fully cached "};
     }
 
     if (width == 0
         || height == 0) // || duration == 0) // no duration check as we can infer duration when decoding frames,
     {
-        const QString error = QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
-        return {error, true};
+        return QString("height (%1) or width (%2) = 0 ").arg(height).arg(width);
     }
     return {};
 }
 
-Video::ProcessingStepResult Video::processFrames(const Db& cache)
+QString Video::processFrames(const Db* cache)
 {
-    const bool durationWasZero = duration == 0;
     const auto err = takeScreenCaptures(cache);
-    if (_prefs.useCacheOption() == Prefs::WITH_CACHE && durationWasZero && duration != 0)
-        cache.writeMetadata(*this); // update cache as takeScreenCaptures can estimate duration, when it was 0
-    if (!err.isEmpty()) {
-        // A capture error can be an unavailable source or temporary resource failure, so let the next scan retry it.
-        return {QString("capture failed: %1").arg(err)};
-    }
-    else if ((_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
-             || // only cutEnds separates fingerprints for captures; other modes treat the collage as one fingerprint
-             (_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
+    if (!err.isEmpty())
+        return QString("capture failed: %1").arg(err);
+    if ((_prefs.thumbnailsMode() != cutEnds && !fingerprint(0).usable)
+        || // only cutEnds separates fingerprints for captures; other modes treat the collage as one fingerprint
+        (_prefs.thumbnailsMode() == cutEnds && !fingerprint(0).usable && !fingerprint(1).usable))
     { //every extracted frame have almost no features/fully flat (e.g. all black)
-        return {"all extracted frames were blank", true};
+        return QStringLiteral("all extracted frames were blank");
     }
     return {};
 }
@@ -300,7 +306,7 @@ const QString Video::getMetadata(const QString& filename)
 }
 
 // returns empty string if success or string with error message
-const QString Video::takeScreenCaptures(const Db& cache)
+const QString Video::takeScreenCaptures(const Db* cache)
 {
     Thumbnail thumb(this->_prefs.thumbnailsMode());
     QImage thumbnail(thumb.cols() * width, thumb.rows() * height, QImage::Format_RGB888);
@@ -362,11 +368,11 @@ const QString Video::takeScreenCaptures(const Db& cache)
         QPainter painter(&thumbnail); //copy captured frame into right place in thumbnail
         painter.drawImage(capture % thumb.cols() * width, capture / thumb.cols() * height, frame);
 
-        if (resolved.writeToCache) {
+        if (resolved.writeToCache && cache != nullptr) {
             QByteArray cachedImage;
             QBuffer captureBuffer(&cachedImage);
             minimizeImage(frame).save(&captureBuffer, QByteArrayLiteral("JPG"), _okJpegQuality);
-            cache.writeCapture(_filePathName, percentages[capture], cachedImage);
+            cache->writeCapture(_filePathName, percentages[capture], cachedImage);
         }
     }
 
@@ -374,15 +380,15 @@ const QString Video::takeScreenCaptures(const Db& cache)
     return "";
 }
 
-Video::ResolvedCapture Video::resolveCaptureSlot(const Db& cache, const int percentage, const int ofDuration)
+Video::ResolvedCapture Video::resolveCaptureSlot(const Db* cache, const int percentage, const int ofDuration)
 {
     ResolvedCapture resolved;
     const bool cacheEnabled = this->_prefs.useCacheOption() == Prefs::WITH_CACHE;
     const bool decodeAllowed = this->_prefs.useCacheOption() != Prefs::CACHE_ONLY;
 
     QByteArray cachedImage;
-    if (this->_prefs.useCacheOption() != Prefs::NO_CACHE)
-        cachedImage = cache.readCapture(_filePathName, percentage);
+    if (cache != nullptr)
+        cachedImage = cache->readCapture(_filePathName, percentage);
 
     if (!cachedImage.isNull()) {
         QBuffer captureBuffer(&cachedImage);

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -88,6 +88,7 @@ Video::ProcessingResult Video::process()
     const QString validationError = validateInput();
     if (!validationError.isEmpty()) {
         result.errorMsg = validationError;
+        // CACHE_ONLY errors are cache misses, not processing failures: don't persist them.
         if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, validationError);
         return result;
@@ -103,6 +104,7 @@ Video::ProcessingResult Video::process()
     QString error = processMetadata(metadataCached);
     if (!error.isEmpty()) {
         result.errorMsg = error;
+        // CACHE_ONLY errors are cache misses, not processing failures: don't persist them.
         if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, error);
         return result;
@@ -111,6 +113,7 @@ Video::ProcessingResult Video::process()
     error = processFrames(cache.get());
     if (!error.isEmpty()) {
         result.errorMsg = error;
+        // CACHE_ONLY errors are cache misses, not processing failures: don't persist them.
         if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, error);
         return result;

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -84,13 +84,11 @@ Video::ProcessingResult Video::process()
     std::unique_ptr<Db> cache;
     if (_prefs.useCacheOption() != Prefs::NO_CACHE)
         cache = std::make_unique<Db>(_prefs.cacheFilePathName());
-    // CACHE_ONLY must stay read-only: never persist failures or rewrite metadata from that mode.
-    const bool canWriteCache = _prefs.useCacheOption() == Prefs::WITH_CACHE && cache != nullptr;
 
     const QString validationError = validateInput();
     if (!validationError.isEmpty()) {
         result.errorMsg = validationError;
-        if (canWriteCache)
+        if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, validationError);
         return result;
     }
@@ -125,7 +123,7 @@ Video::ProcessingResult Video::process()
     QString error = processMetadata(metadataCached);
     if (!error.isEmpty()) {
         result.errorMsg = error;
-        if (canWriteCache)
+        if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, error);
         return result;
     }
@@ -133,7 +131,7 @@ Video::ProcessingResult Video::process()
     error = processFrames(cache.get());
     if (!error.isEmpty()) {
         result.errorMsg = error;
-        if (canWriteCache)
+        if (_prefs.useCacheOption() == Prefs::WITH_CACHE)
             cache->writeFailure(_filePathName, error);
         return result;
     }
@@ -141,7 +139,7 @@ Video::ProcessingResult Video::process()
     result.success = true;
     // Cache metadata only after a full successful run: duration may still be 0 after metadata extraction
     // and get inferred later while decoding frames, so we wait until both stages finish.
-    if (canWriteCache && !metadataCached)
+    if (_prefs.useCacheOption() == Prefs::WITH_CACHE && !metadataCached)
         cache->writeMetadata(*this);
     return result;
 }

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -93,31 +93,11 @@ Video::ProcessingResult Video::process()
         return result;
     }
 
-    bool metadataCached = cache != nullptr && cache->readMetadata(*this);
+    const bool metadataCached = cache != nullptr && cache->readMetadata(*this);
     if (metadataCached && !cachedFailure.isEmpty()) {
         result.errorMsg =
             QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure);
         return result;
-    }
-
-    if (metadataCached) {
-        const QFileInfo info(_filePathName);
-        const QDateTime liveModified = info.lastModified();
-        // Cached modified/birth_time avoid filesystem stats on warm hits, but a changed file under the same
-        // path must drop stale metadata and captures rather than reuse them for matching or auto-delete.
-        if (modified.isValid() && liveModified.isValid()
-            && modified.toMSecsSinceEpoch() != liveModified.toMSecsSinceEpoch()) {
-            cache->removeVideo(_filePathName);
-            metadataCached = false;
-            modified = {};
-            _fileCreateDate = {};
-            cachedFailure.clear();
-        } else if (!modified.isValid()) {
-            // Legacy rows without dates: use live timestamps without forcing a re-extract.
-            modified = liveModified;
-            if (info.birthTime().isValid())
-                _fileCreateDate = info.birthTime();
-        }
     }
 
     QString error = processMetadata(metadataCached);

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -84,26 +84,48 @@ Video::ProcessingResult Video::process()
     std::unique_ptr<Db> cache;
     if (_prefs.useCacheOption() != Prefs::NO_CACHE)
         cache = std::make_unique<Db>(_prefs.cacheFilePathName());
+    // CACHE_ONLY must stay read-only: never persist failures or rewrite metadata from that mode.
+    const bool canWriteCache = _prefs.useCacheOption() == Prefs::WITH_CACHE && cache != nullptr;
 
     const QString validationError = validateInput();
     if (!validationError.isEmpty()) {
         result.errorMsg = validationError;
-        if (cache != nullptr)
+        if (canWriteCache)
             cache->writeFailure(_filePathName, validationError);
         return result;
     }
 
-    const bool metadataCached = cache != nullptr && cache->readMetadata(*this);
+    bool metadataCached = cache != nullptr && cache->readMetadata(*this);
     if (metadataCached && !cachedFailure.isEmpty()) {
         result.errorMsg =
             QString("skipped, cache indicated it had failed in a previous scan with: %1").arg(cachedFailure);
         return result;
     }
 
+    if (metadataCached) {
+        const QFileInfo info(_filePathName);
+        const QDateTime liveModified = info.lastModified();
+        // Cached modified/birth_time avoid filesystem stats on warm hits, but a changed file under the same
+        // path must drop stale metadata and captures rather than reuse them for matching or auto-delete.
+        if (modified.isValid() && liveModified.isValid()
+            && modified.toMSecsSinceEpoch() != liveModified.toMSecsSinceEpoch()) {
+            cache->removeVideo(_filePathName);
+            metadataCached = false;
+            modified = {};
+            _fileCreateDate = {};
+            cachedFailure.clear();
+        } else if (!modified.isValid()) {
+            // Legacy rows without dates: use live timestamps without forcing a re-extract.
+            modified = liveModified;
+            if (info.birthTime().isValid())
+                _fileCreateDate = info.birthTime();
+        }
+    }
+
     QString error = processMetadata(metadataCached);
     if (!error.isEmpty()) {
         result.errorMsg = error;
-        if (cache != nullptr)
+        if (canWriteCache)
             cache->writeFailure(_filePathName, error);
         return result;
     }
@@ -111,7 +133,7 @@ Video::ProcessingResult Video::process()
     error = processFrames(cache.get());
     if (!error.isEmpty()) {
         result.errorMsg = error;
-        if (cache != nullptr)
+        if (canWriteCache)
             cache->writeFailure(_filePathName, error);
         return result;
     }
@@ -119,7 +141,7 @@ Video::ProcessingResult Video::process()
     result.success = true;
     // Cache metadata only after a full successful run: duration may still be 0 after metadata extraction
     // and get inferred later while decoding frames, so we wait until both stages finish.
-    if (cache != nullptr && !metadataCached)
+    if (canWriteCache && !metadataCached)
         cache->writeMetadata(*this);
     return result;
 }

--- a/QtProject/app/video.h
+++ b/QtProject/app/video.h
@@ -48,8 +48,8 @@ class Video : public QObject
     QString nameInApplePhotos;
     int64_t size = 0; // in bytes
     // Filled by readMetadata: empty when the cached metadata is usable, otherwise this path already failed processing
-    // and the scan can skip FFmpeg from that same query. Failures are recorded with Db::writeFailure. Thumbnail mode is
-    // ignored: retrying is emptying the cache, or scanning without it.
+    // and the scan can skip FFmpeg from that same query. process() persists deterministic step failures after extraction
+    // returns. Thumbnail mode is ignored: retrying is emptying the cache, or scanning without it.
     QString cachedFailure;
     QDateTime modified;
     QDateTime _fileCreateDate;
@@ -80,6 +80,11 @@ class Video : public QObject
                                const int ofDuration = 100); // new methods for capture of image, using ffmpeg library
 
   private:
+    struct ProcessingStepResult {
+        QString error;
+        bool cacheFailure = false;
+    };
+
     struct ResolvedCapture {
         QImage frame;
         FrameAnalysis analysis;
@@ -89,11 +94,13 @@ class Video : public QObject
         QString error;
     };
 
+    QString validateInput() const;
+    ProcessingStepResult processMetadata(const Db& cache);
+    ProcessingStepResult processFrames(const Db& cache);
     const QString getMetadata(const QString& filename); // returns error message or empty string if success
     const QString takeScreenCaptures(const Db& cache);
     // Content-quality selection is separate from the outer decode-failure retry.
     ResolvedCapture resolveCaptureSlot(const Db& cache, int percentage, int ofDuration);
-    QString internalProcess();
     // Builds the comparison fingerprints from the selected frames and their analyses, then stores a minimized copy of
     // the original collage for the review UI. Cached and decoded frames have already followed the same analysis path.
     void processThumbnail(QImage& thumbnail, const Thumbnail& thumb, const std::vector<FrameAnalysis>& analyses);

--- a/QtProject/app/video.h
+++ b/QtProject/app/video.h
@@ -48,8 +48,8 @@ class Video : public QObject
     QString nameInApplePhotos;
     int64_t size = 0; // in bytes
     // Filled by readMetadata: empty when the cached metadata is usable, otherwise this path already failed processing
-    // and the scan can skip FFmpeg from that same query. process() persists deterministic step failures after extraction
-    // returns. Thumbnail mode is ignored: retrying is emptying the cache, or scanning without it.
+    // and the scan can skip FFmpeg from that same query. process() persists failures after extraction returns.
+    // Thumbnail mode is ignored: retrying is emptying the cache, or scanning without it.
     QString cachedFailure;
     QDateTime modified;
     QDateTime _fileCreateDate;
@@ -80,11 +80,6 @@ class Video : public QObject
                                const int ofDuration = 100); // new methods for capture of image, using ffmpeg library
 
   private:
-    struct ProcessingStepResult {
-        QString error;
-        bool cacheFailure = false;
-    };
-
     struct ResolvedCapture {
         QImage frame;
         FrameAnalysis analysis;
@@ -95,12 +90,12 @@ class Video : public QObject
     };
 
     QString validateInput() const;
-    ProcessingStepResult processMetadata(const Db& cache);
-    ProcessingStepResult processFrames(const Db& cache);
+    QString processMetadata(bool metadataCached);
+    QString processFrames(const Db* cache);
     const QString getMetadata(const QString& filename); // returns error message or empty string if success
-    const QString takeScreenCaptures(const Db& cache);
+    const QString takeScreenCaptures(const Db* cache);
     // Content-quality selection is separate from the outer decode-failure retry.
-    ResolvedCapture resolveCaptureSlot(const Db& cache, int percentage, int ofDuration);
+    ResolvedCapture resolveCaptureSlot(const Db* cache, int percentage, int ofDuration);
     // Builds the comparison fingerprints from the selected frames and their analyses, then stores a minimized copy of
     // the original collage for the review UI. Cached and decoded frames have already followed the same analysis path.
     void processThumbnail(QImage& thumbnail, const Thumbnail& thumb, const std::vector<FrameAnalysis>& analyses);

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -92,6 +92,7 @@ class TestFailedVideoCache : public QObject
     void init();
     void cleanup();
     void test_processingCachePolicy();
+    void test_metadataDatesAreCached();
     void test_databaseClearingAndRemoval();
     void test_failureSkipsUntilCacheBypassedOrEmptied();
 };
@@ -117,41 +118,33 @@ void TestFailedVideoCache::test_processingCachePolicy()
     const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(Db::emptyAllDb(prefs));
 
-    // Generic metadata/open failures may be environmental or transient, so unchanged files must remain retryable.
     const QString firstMetadataError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(firstMetadataError.contains(QStringLiteral("could not read metadata")));
-    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
-    const QString secondMetadataError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(secondMetadataError.contains(QStringLiteral("could not read metadata")));
-    QVERIFY(!secondMetadataError.startsWith(QStringLiteral("skipped, cache indicated")));
+    QCOMPARE(cachedFailure(cachePath, transientPath), firstMetadataError);
+    QCOMPARE(processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds), skippedMessage(firstMetadataError));
 
-    // Cached metadata gets the invalid file into the capture/decode path, whose failures may also be transient.
     {
         Db cache(cachePath);
         writePlausibleMetadata(cache, prefs, transientPath, QFileInfo(transientPath).size());
     }
     const QString captureError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(captureError.contains(QStringLiteral("capture failed")));
-    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
-    const QString retryCaptureError = processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(retryCaptureError.contains(QStringLiteral("capture failed")));
-    QVERIFY(!retryCaptureError.startsWith(QStringLiteral("skipped, cache indicated")));
-
-    const QString otherModeError = processError(transientPath, cachePath, Prefs::WITH_CACHE, thumb1);
-    QVERIFY(otherModeError.contains(QStringLiteral("capture failed")));
-    QVERIFY(!otherModeError.startsWith(QStringLiteral("skipped, cache indicated")));
+    QCOMPARE(cachedFailure(cachePath, transientPath), captureError);
+    QCOMPARE(processError(transientPath, cachePath, Prefs::WITH_CACHE, cutEnds), skippedMessage(captureError));
+    QCOMPARE(processError(transientPath, cachePath, Prefs::WITH_CACHE, thumb1), skippedMessage(captureError));
 
     const QString noCacheError = processError(transientPath, cachePath, Prefs::NO_CACHE, cutEnds);
     QVERIFY(noCacheError.contains(QStringLiteral("could not read metadata")));
     QVERIFY(!noCacheError.startsWith(QStringLiteral("skipped, cache indicated")));
-    QVERIFY(cachedFailure(cachePath, transientPath).isEmpty());
+    QCOMPARE(cachedFailure(cachePath, transientPath), captureError);
 
-    const QString cacheOnlyError = processError(transientPath, cachePath, Prefs::CACHE_ONLY, cutEnds);
-    QVERIFY(!cacheOnlyError.isEmpty());
-    QVERIFY(!cacheOnlyError.startsWith(QStringLiteral("skipped, cache indicated")));
-    const QString cacheOnlyMiss = processError(transientPath, cachePath, Prefs::CACHE_ONLY, thumb3);
-    QVERIFY(!cacheOnlyMiss.isEmpty());
-    QVERIFY(!cacheOnlyMiss.startsWith(QStringLiteral("skipped, cache indicated")));
+    QCOMPARE(processError(transientPath, cachePath, Prefs::CACHE_ONLY, cutEnds), skippedMessage(captureError));
+    QCOMPARE(processError(transientPath, cachePath, Prefs::CACHE_ONLY, thumb1), skippedMessage(captureError));
+
+    const QString uncachedPath = temporary.filePath(QStringLiteral("uncached.mp4"));
+    QVERIFY(writeInvalidVideo(uncachedPath, QByteArrayLiteral("not a video")));
+    QVERIFY(processError(uncachedPath, cachePath, Prefs::CACHE_ONLY, cutEnds)
+                .contains(QStringLiteral("video was not fully cached")));
 
     const QString terminalPath = temporary.filePath(QStringLiteral("all-black.mp4"));
     QVERIFY(writeInvalidVideo(terminalPath, QByteArrayLiteral("not a video")));
@@ -162,26 +155,23 @@ void TestFailedVideoCache::test_processingCachePolicy()
         for (const int percentage : Thumbnail(cutEnds).percentages())
             cache.writeCapture(terminalPath, percentage, black);
     }
-    // A substitute decode can fail temporarily even though the cached primary frame is black.
     const QString substituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(substituteError.contains(QStringLiteral("was blank and an attempted replacement")));
-    QVERIFY(cachedFailure(cachePath, terminalPath).isEmpty());
-    const QString retrySubstituteError = processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(retrySubstituteError.contains(QStringLiteral("was blank and an attempted replacement")));
-    QVERIFY(!retrySubstituteError.startsWith(QStringLiteral("skipped, cache indicated")));
+    QCOMPARE(cachedFailure(cachePath, terminalPath), substituteError);
+    QCOMPARE(processError(terminalPath, cachePath, Prefs::WITH_CACHE, cutEnds), skippedMessage(substituteError));
 
     const QString missingPath = temporary.filePath(QStringLiteral("missing.mp4"));
-    QVERIFY(processError(missingPath, cachePath, Prefs::WITH_CACHE, cutEnds)
-                .contains(QStringLiteral("doesn't seem to exist")));
-    QVERIFY(!hasMetadata(cachePath, missingPath));
+    const QString missingError = processError(missingPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(missingError.contains(QStringLiteral("doesn't seem to exist")));
+    QVERIFY(hasMetadata(cachePath, missingPath));
+    QCOMPARE(cachedFailure(cachePath, missingPath), missingError);
 
     const QString emptyPath = temporary.filePath(QStringLiteral("empty.mp4"));
     QVERIFY(writeInvalidVideo(emptyPath, {}));
-    QVERIFY(processError(emptyPath, cachePath, Prefs::WITH_CACHE, cutEnds).contains(QStringLiteral("file size = 0")));
-    QVERIFY(cachedFailure(cachePath, emptyPath).isEmpty());
+    const QString emptyError = processError(emptyPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(emptyError.contains(QStringLiteral("file size = 0")));
+    QCOMPARE(cachedFailure(cachePath, emptyPath), emptyError);
 
-    // Zero dimensions cannot become valid on a later scan, so the scan itself must record the failure, and it must do
-    // so without disturbing the metadata already cached for that path.
     const QString zeroDimensionsPath = temporary.filePath(QStringLiteral("zero-dimensions.mp4"));
     QVERIFY(writeInvalidVideo(zeroDimensionsPath, QByteArrayLiteral("not a video")));
     {
@@ -194,13 +184,48 @@ void TestFailedVideoCache::test_processingCachePolicy()
     {
         Video cached(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), zeroDimensionsPath);
         QVERIFY(Db(cachePath).readMetadata(cached));
-        QCOMPARE(cached.size, QFileInfo(zeroDimensionsPath).size());
-        QCOMPARE(cached.duration, 1000);
-        QCOMPARE(cached.bitrate, 100);
-        QCOMPARE(cached.codec, QStringLiteral("test"));
+        QCOMPARE(cached.size, 0);
+        QCOMPARE(cached.duration, 0);
+        QCOMPARE(cached.bitrate, 0);
+        QCOMPARE(cached.codec, QString());
+        QCOMPARE(cached.cachedFailure, zeroDimensionsError);
     }
     QCOMPARE(processError(zeroDimensionsPath, cachePath, Prefs::WITH_CACHE, cutEnds),
              skippedMessage(zeroDimensionsError));
+}
+
+void TestFailedVideoCache::test_metadataDatesAreCached()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("dated.mp4"));
+    QVERIFY(writeInvalidVideo(videoPath, QByteArrayLiteral("not a video")));
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+
+    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0));
+    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0));
+    {
+        Db cache(cachePath);
+        Video metadata(prefs, videoPath);
+        metadata.size = 12;
+        metadata.duration = 1000;
+        metadata.bitrate = 100;
+        metadata.framerate = 25;
+        metadata.codec = QStringLiteral("test");
+        metadata.width = 16;
+        metadata.height = 16;
+        metadata.modified = modified;
+        metadata._fileCreateDate = birthTime;
+        cache.writeMetadata(metadata);
+    }
+
+    Video loaded(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), videoPath);
+    QVERIFY(Db(cachePath).readMetadata(loaded));
+    QCOMPARE(loaded.modified, modified);
+    QCOMPARE(loaded._fileCreateDate, birthTime);
 }
 
 void TestFailedVideoCache::test_databaseClearingAndRemoval()
@@ -255,7 +280,7 @@ void TestFailedVideoCache::test_failureSkipsUntilCacheBypassedOrEmptied()
     QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, thumb1),
              skippedMessage(QStringLiteral("all extracted frames were blank")));
 
-    // Scanning without the cache must reach FFmpeg again, and must not record a new failure.
+    // Scanning without the cache must reach FFmpeg again, and must not overwrite the cached failure.
     const QString bypassedError = processError(videoPath, cachePath, Prefs::NO_CACHE, cutEnds);
     QVERIFY(bypassedError.contains(QStringLiteral("could not read metadata")));
     QCOMPARE(cachedFailure(cachePath, videoPath), QStringLiteral("all extracted frames were blank"));
@@ -264,7 +289,7 @@ void TestFailedVideoCache::test_failureSkipsUntilCacheBypassedOrEmptied()
     QVERIFY(cachedFailure(cachePath, videoPath).isEmpty());
     const QString retryError = processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(retryError.contains(QStringLiteral("could not read metadata")));
-    QVERIFY(!retryError.startsWith(QStringLiteral("skipped, cache indicated")));
+    QCOMPARE(cachedFailure(cachePath, videoPath), retryError);
 }
 
 QTEST_MAIN(TestFailedVideoCache)

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -94,7 +94,6 @@ class TestFailedVideoCache : public QObject
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
     void test_cacheOnlyDoesNotPersistFailures();
-    void test_changedFileInvalidatesCache();
     void test_databaseClearingAndRemoval();
     void test_failureSkipsUntilCacheBypassedOrEmptied();
 };
@@ -207,8 +206,8 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(Db::emptyAllDb(prefs));
 
-    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0, 456));
-    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0, 789));
+    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0));
+    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0));
     {
         Db cache(cachePath);
         Video metadata(prefs, videoPath);
@@ -226,8 +225,8 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
 
     Video loaded(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), videoPath);
     QVERIFY(Db(cachePath).readMetadata(loaded));
-    QCOMPARE(loaded.modified.toMSecsSinceEpoch(), modified.toMSecsSinceEpoch());
-    QCOMPARE(loaded._fileCreateDate.toMSecsSinceEpoch(), birthTime.toMSecsSinceEpoch());
+    QCOMPARE(loaded.modified, modified);
+    QCOMPARE(loaded._fileCreateDate, birthTime);
 }
 
 void TestFailedVideoCache::test_cacheOnlyDoesNotPersistFailures()
@@ -256,43 +255,6 @@ void TestFailedVideoCache::test_cacheOnlyDoesNotPersistFailures()
         QCOMPARE(cached.codec, QStringLiteral("test"));
         QVERIFY(cached.cachedFailure.isEmpty());
     }
-}
-
-void TestFailedVideoCache::test_changedFileInvalidatesCache()
-{
-    QTemporaryDir temporary;
-    QVERIFY(temporary.isValid());
-    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
-    const QString videoPath = temporary.filePath(QStringLiteral("replaced.mp4"));
-    QVERIFY(writeInvalidVideo(videoPath, QByteArrayLiteral("not a video")));
-
-    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(Db::emptyAllDb(prefs));
-
-    const QDateTime staleModified = QFileInfo(videoPath).lastModified().addSecs(-3600);
-    {
-        Db cache(cachePath);
-        Video metadata(prefs, videoPath);
-        metadata.size = QFileInfo(videoPath).size();
-        metadata.duration = 1000;
-        metadata.bitrate = 100;
-        metadata.framerate = 25;
-        metadata.codec = QStringLiteral("stale");
-        metadata.width = 16;
-        metadata.height = 16;
-        metadata.modified = staleModified;
-        metadata._fileCreateDate = staleModified;
-        cache.writeMetadata(metadata);
-        cache.writeCapture(videoPath, 8, blackCapture());
-    }
-
-    QVERIFY(hasMetadata(cachePath, videoPath));
-    QVERIFY(!Db(cachePath).readCapture(videoPath, 8).isNull());
-
-    const QString error = processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(error.contains(QStringLiteral("could not read metadata")));
-    QCOMPARE(cachedFailure(cachePath, videoPath), error);
-    QVERIFY(Db(cachePath).readCapture(videoPath, 8).isNull());
 }
 
 void TestFailedVideoCache::test_databaseClearingAndRemoval()

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -93,6 +93,8 @@ class TestFailedVideoCache : public QObject
     void cleanup();
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
+    void test_cacheOnlyDoesNotPersistFailures();
+    void test_changedFileInvalidatesCache();
     void test_databaseClearingAndRemoval();
     void test_failureSkipsUntilCacheBypassedOrEmptied();
 };
@@ -205,8 +207,8 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(Db::emptyAllDb(prefs));
 
-    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0));
-    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0));
+    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0, 456));
+    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0, 789));
     {
         Db cache(cachePath);
         Video metadata(prefs, videoPath);
@@ -224,8 +226,73 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
 
     Video loaded(cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds), videoPath);
     QVERIFY(Db(cachePath).readMetadata(loaded));
-    QCOMPARE(loaded.modified, modified);
-    QCOMPARE(loaded._fileCreateDate, birthTime);
+    QCOMPARE(loaded.modified.toMSecsSinceEpoch(), modified.toMSecsSinceEpoch());
+    QCOMPARE(loaded._fileCreateDate.toMSecsSinceEpoch(), birthTime.toMSecsSinceEpoch());
+}
+
+void TestFailedVideoCache::test_cacheOnlyDoesNotPersistFailures()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("partial.mp4"));
+    QVERIFY(writeInvalidVideo(videoPath, QByteArrayLiteral("not a video")));
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+    {
+        Db cache(cachePath);
+        writePlausibleMetadata(cache, prefs, videoPath, QFileInfo(videoPath).size());
+    }
+
+    const QString cacheOnlyError = processError(videoPath, cachePath, Prefs::CACHE_ONLY, cutEnds);
+    QVERIFY(cacheOnlyError.contains(QStringLiteral("capture failed")));
+    QVERIFY(cachedFailure(cachePath, videoPath).isEmpty());
+    {
+        Video cached(prefs, videoPath);
+        QVERIFY(Db(cachePath).readMetadata(cached));
+        QCOMPARE(cached.size, QFileInfo(videoPath).size());
+        QCOMPARE(cached.duration, 1000);
+        QCOMPARE(cached.codec, QStringLiteral("test"));
+        QVERIFY(cached.cachedFailure.isEmpty());
+    }
+}
+
+void TestFailedVideoCache::test_changedFileInvalidatesCache()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("replaced.mp4"));
+    QVERIFY(writeInvalidVideo(videoPath, QByteArrayLiteral("not a video")));
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+
+    const QDateTime staleModified = QFileInfo(videoPath).lastModified().addSecs(-3600);
+    {
+        Db cache(cachePath);
+        Video metadata(prefs, videoPath);
+        metadata.size = QFileInfo(videoPath).size();
+        metadata.duration = 1000;
+        metadata.bitrate = 100;
+        metadata.framerate = 25;
+        metadata.codec = QStringLiteral("stale");
+        metadata.width = 16;
+        metadata.height = 16;
+        metadata.modified = staleModified;
+        metadata._fileCreateDate = staleModified;
+        cache.writeMetadata(metadata);
+        cache.writeCapture(videoPath, 8, blackCapture());
+    }
+
+    QVERIFY(hasMetadata(cachePath, videoPath));
+    QVERIFY(!Db(cachePath).readCapture(videoPath, 8).isNull());
+
+    const QString error = processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(error.contains(QStringLiteral("could not read metadata")));
+    QCOMPARE(cachedFailure(cachePath, videoPath), error);
+    QVERIFY(Db(cachePath).readCapture(videoPath, 8).isNull());
 }
 
 void TestFailedVideoCache::test_databaseClearingAndRemoval()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues / supersedes #212 with a clearer framing of the behavior change.

The stage split (`validateInput` / `processMetadata` / `processFrames`) is supporting structure. The impactful changes are:

- Persist **every** processing failure via an upserting `writeFailure()` (not only terminal blank-frame / zero-dimension cases), so later `WITH_CACHE` scans skip those paths until the cache is emptied or bypassed
- Persist `modified` / `birth_time` on the metadata row so warm hits can avoid filesystem stats
- Write successful metadata **once** after both stages finish (duration may still be inferred during frame decode)
- Only `WITH_CACHE` writes failures/metadata (`CACHE_ONLY` stays read-only)

## Test plan

- [x] Configure CI-style Linux debug build (`cmake -S QtProject -B … -G Ninja -DCMAKE_BUILD_TYPE=Debug`)
- [x] Build and run `test_failed_video_cache` (covers CACHE_ONLY not persisting failures)
- [x] Run self-contained baseline: `test_comparison`, `test_mainwindow`, `test_failed_video_cache`, `test_repo_auto_delete`, `test_repo_video_matching`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08c13-c6b1-740f-ac00-b050867eb403?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08c13-c6b1-740f-ac00-b050867eb403&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

