### PR TITLE
fix(release): heal dateless cache rows, skip hidden entries, auto trash rotated matches, millisecond timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This is a C++ desktop app built with CMake and relying on static libraries like 
 
 - `QtProject/app`: main application code. `MainWindow` handles scanning/progress, `Video` extracts metadata/thumbnails/hashes, `Comparison` reviews matches and cleanup actions, `Db` owns cache persistence.
 - `QtProject/app/*.ui`: Qt Designer forms with auto-connected `on_<object>_<signal>` slots. Keep UI changes consistent with the generated `ui_*.h` flow.
-- `QtProject/tests`: `test_repo_*` targets are self-contained and use only checked-in fixtures under `QtProject/tests/repo`. Optional corpora live under `QtProject/tests/external` and use flat `test_external_*` target names. `test_repo_auto_delete` covers focused end-to-end cleanup; `test_repo_video_extraction_regression` snapshots the Nice videos; and `test_repo_video_matching` validates the tracked matching manifest.
+- `QtProject/tests`: self-contained tests (`test_repo_*` and the other `test_*` targets) use only tracked fixtures from `samples/videos`, copied into temporary folders when they need to mutate them, plus generated temp files. Prefer a real tracked video over synthetic bytes when the code under test has to succeed at extraction. Only `test_external_*` targets (under `QtProject/tests/external`) may depend on the optional `~/Dev` corpora.
 - `samples/videos`: small representative fixtures for video-processing tests. Avoid replacing binary fixtures unless needed for the test intent.
 - Keep repository-tracked video fixtures within a few MB total because every clone downloads them.
 - Keep the out of repo, optional `~/Dev` video corpus lean as well; a few GB total is acceptable.
@@ -32,18 +32,14 @@ The main development platform is macOS; keep default agent commands on this path
 
 - Configure: `cmake -S QtProject --preset debug-6.10.1-macos`
 - Build: `cmake --build QtProject/builds/build-debug-6.10.1-macos`
-- Run focused auto-delete end-to-end tests after changing cleanup behavior or auto cleanup UI:
-  `cmake --build QtProject/builds/build-debug-6.10.1-macos --target test_repo_auto_delete && ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R ^test_repo_auto_delete$`
 - Run the self-contained CTest baseline:
   `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -C Debug --output-on-failure -R "^(test_comparison|test_mainwindow|test_failed_video_cache|test_repo_auto_delete|test_repo_video_matching)$"`
-- Run `test_failed_video_cache` after changing which processing failures are treated as permanent versus retryable. It is self-contained and uses generated temporary files.
+- Prefer targeted `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -R ^<target>$` invocations when using CTest on macOS; the test CMake config chooses a platform plugin compatible with the current Qt build.
 - CTest labels make the safe lanes explicit: `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos -L repo-fixtures` runs tracked fixtures, while `-L external-fixtures` runs the optional `~/Dev` suites. `test_external_large_video_corpus` is separately labeled `external-corpus` and `requires-mounted-100gb`; run only its named functions.
-- Green `test_external_whole_app_scan` function cases for regular external-corpus work: `emptyDb`, `test_whole_app_nocache`, `test_whole_app_cached`, `test_whole_app_cache_only`.
 - `test_repo_video_extraction_regression` compares platform-sensitive metadata/thumbnails for the Nice videos; run it on the macOS dev setup, not Linux CI, unless refreshing reference expectations.
-- `test_external_video_extraction_regression` compares every `~/Dev` video against its metadata and thumbnail references in each cache mode. Reference-detail cases (`test_check_refvidparams_nocache`, `test_check_refvidparams_withcache`, `test_check_refvidparams_withCacheOnly`) are not all green currently; run them when touching metadata, thumbnails, cache behavior, or reference data.
-- `test_external_whole_app_scan` runs `~/Dev` end-to-end scans in each cache mode; run its explicit functions only when that corpus is available.
+- `test_external_video_extraction_regression` compares every `~/Dev` video against its metadata and thumbnail references in each cache mode. Reference-detail cases (`test_check_refvidparams_nocache`, `test_check_refvidparams_withcache`, `test_check_refvidparams_withCacheOnly`) are not all green currently.
+- Green `test_external_whole_app_scan` function cases when that corpus is available: `emptyDb`, `test_whole_app_nocache`, `test_whole_app_cached`, `test_whole_app_cache_only`.
 - To investigate one `~/Dev` extraction reference, run a single `test_external_video_extraction_regression` data row, for example `test_check_refvidparams_nocache:20150727_115225.mp4`.
-- Prefer targeted `ctest --test-dir QtProject/builds/build-debug-6.10.1-macos ...` invocations when using CTest on macOS; the test CMake config chooses a platform plugin compatible with the current Qt build.
 - Do not run `test_external_large_video_corpus` unless explicitly requested; its active functions require the mounted 100GB folder.
 - Package macOS binaries: `npm run binaries`
 - Rebuild vendored macOS deps only when needed: `npm run qt-macos`, `npm run ffmpeg-macos`, `npm run opencv-macos`
@@ -56,8 +52,7 @@ Use the `debug-linux` CMake preset (Ninja + `g++`, `CMAKE_PREFIX_PATH` / `PKG_CO
 
 - Configure: `cmake -S QtProject --preset debug-linux`
 - Build: `cmake --build QtProject/builds/build-debug-linux`
-- Run the self-contained CTest baseline:
- `ctest --test-dir QtProject/builds/build-debug-linux --output-on-failure -R "^(test_comparison|test_mainwindow|test_failed_video_cache|test_repo_auto_delete|test_repo_video_matching)$"`
+- Run the same self-contained CTest baseline as macOS, with `--test-dir QtProject/builds/build-debug-linux`
 - Run the app: `QtProject/builds/build-debug-linux/video-simili-duplicate-cleaner`
 - Do not gate Linux runs on `test_repo_video_extraction_regression`: its Nice-video metadata/thumbnail hashes are macOS-specific and mismatch on Linux by design (verify those on macOS). The `repo-fixtures` label includes it, so prefer the explicit baseline above on Linux.
 - GitHub `linux-local-tests` still uses Ubuntu system packages and a one-off CMake build dir, not this preset.

--- a/QtProject/app/comparison/comparison.cpp
+++ b/QtProject/app/comparison/comparison.cpp
@@ -309,6 +309,7 @@ bool Comparison::bothVideosMatch(const Video* left, const Video* right)
     const auto result = VideoPairMatcher::match(*left, *right, VideoPairMatcher::configFromPrefs(_prefs));
     _phashSimilarity = result.phashSimilarity;
     _ssimSimilarity = result.ssimSimilarity;
+    _matchRotation = result.rotation;
     if (!result.matches)
         return false;
     // check if pair is flagged as not dupplicate in DB. DB is very slow so only do this after all checks
@@ -1467,9 +1468,9 @@ void Comparison::on_identicalFilesAutoTrash_clicked()
                     continue;
                 if (_videos[_leftVideo]->duration != _videos[_rightVideo]->duration)
                     continue;
-                if (_videos[_leftVideo]->height != _videos[_rightVideo]->height)
-                    continue;
-                if (_videos[_leftVideo]->width != _videos[_rightVideo]->width)
+                if (!sameResolutionUnderRotation(_videos[_leftVideo]->width, _videos[_leftVideo]->height,
+                                                 _videos[_rightVideo]->width, _videos[_rightVideo]->height,
+                                                 _matchRotation))
                     continue;
                 if (qAbs(_videos[_leftVideo]->bitrate - _videos[_rightVideo]->bitrate)
                     > BITRATE_DIFF_STILL_EQUAL_kbs) //leave some margin due to decoding error
@@ -1584,9 +1585,9 @@ void Comparison::on_autoDelOnlySizeDiffersButton_clicked()
                     > VIDEO_DURATION_STILL_EQUALS_MS) // video durations more than 1 second length difference
                     continue;
                 if (!ui->autoOnlySizeDontCheckResFpsCheckbox->isChecked()) {
-                    if (_videos[_leftVideo]->height != _videos[_rightVideo]->height)
-                        continue;
-                    if (_videos[_leftVideo]->width != _videos[_rightVideo]->width)
+                    if (!sameResolutionUnderRotation(_videos[_leftVideo]->width, _videos[_leftVideo]->height,
+                                                     _videos[_rightVideo]->width, _videos[_rightVideo]->height,
+                                                     _matchRotation))
                         continue;
                     if (qAbs(_videos[_leftVideo]->framerate - _videos[_rightVideo]->framerate)
                         > 0.1) //both framerates more than 0.1 fps different
@@ -1704,7 +1705,7 @@ void Comparison::autoDeleteLoopthrough(const AutoDeleteConfig autoDelConfig)
 
                 const VideoMetadata* vidToDeleteMetaPtr = autoDelConfig.videoToDelete(
                     &leftVidMeta, &rightVidMeta,
-                    AutoDeleteUserSettings(ui->radioButton_onlyTimeDiffers_trashEarlier->isChecked()));
+                    AutoDeleteUserSettings(ui->radioButton_onlyTimeDiffers_trashEarlier->isChecked()), _matchRotation);
                 if (vidToDeleteMetaPtr == nullptr) // null means the videos don't match in the auto mode
                     continue;
 
@@ -1778,7 +1779,8 @@ void Comparison::autoDeleteLoopthrough(const AutoDeleteConfig autoDelConfig)
 }
 
 const VideoMetadata* Comparison::AutoDeleteConfig::videoToDelete(const VideoMetadata* meta1, const VideoMetadata* meta2,
-                                                                 const AutoDeleteUserSettings userAutoDelConf) const
+                                                                 const AutoDeleteUserSettings userAutoDelConf,
+                                                                 const FingerprintRotation matchRotation) const
 {
     if (_autoDelConfig == AUTO_DELETE_ONLY_TIMES_DIFF) {
 
@@ -1786,9 +1788,7 @@ const VideoMetadata* Comparison::AutoDeleteConfig::videoToDelete(const VideoMeta
             return nullptr;
         if (qAbs(meta1->duration - meta2->duration) > VIDEO_DURATION_STILL_EQUALS_MS)
             return nullptr;
-        if (meta1->height != meta2->height)
-            return nullptr;
-        if (meta1->width != meta2->width)
+        if (!sameResolutionUnderRotation(meta1->width, meta1->height, meta2->width, meta2->height, matchRotation))
             return nullptr;
         if (qAbs(meta1->bitrate - meta2->bitrate)
             > BITRATE_DIFF_STILL_EQUAL_kbs) //leave some margin due to decoding error

--- a/QtProject/app/comparison/comparison.h
+++ b/QtProject/app/comparison/comparison.h
@@ -16,6 +16,8 @@
 #include <functional>
 #include <memory>
 
+#include "visualfingerprint.h"
+
 #ifdef Q_OS_MACOS
 #include "obj-c.h"
 #endif
@@ -56,6 +58,7 @@ class Comparison : public QDialog
 
     int _phashSimilarity = 0;
     double _ssimSimilarity = 0.0;
+    FingerprintRotation _matchRotation = FingerprintRotation::none; // of the pair bothVideosMatch() last accepted
 
     int _zoomLevel = 0;
     QPixmap _leftZoomed;
@@ -106,8 +109,10 @@ class Comparison : public QDialog
 
         QString getDeleteByText() const;
 
-        const VideoMetadata* videoToDelete(const VideoMetadata*, const VideoMetadata*,
-                                           const AutoDeleteUserSettings) const; //returns null if none should be deleted
+        // Returns null if none should be deleted. matchRotation is the rotation the pair matched under, so a rotated
+        // copy is compared on its swapped resolution rather than rejected for having different raw dimensions.
+        const VideoMetadata* videoToDelete(const VideoMetadata*, const VideoMetadata*, const AutoDeleteUserSettings,
+                                           FingerprintRotation matchRotation) const;
 
       private:
         const AUTO_DELETE_CONFIG _autoDelConfig;

--- a/QtProject/app/comparison/internal/videopairmatcher.cpp
+++ b/QtProject/app/comparison/internal/videopairmatcher.cpp
@@ -71,6 +71,16 @@ VideoPairMatchResult scoreFingerprints(const Video& leftVideo, const Video& righ
 }
 } // namespace
 
+bool sameResolutionUnderRotation(const short leftWidth, const short leftHeight, const short rightWidth,
+                                 const short rightHeight, const FingerprintRotation rotation)
+{
+    const bool quarterTurn =
+        rotation == FingerprintRotation::clockwise90 || rotation == FingerprintRotation::counterClockwise90;
+    if (quarterTurn)
+        return leftWidth == rightHeight && leftHeight == rightWidth;
+    return leftWidth == rightWidth && leftHeight == rightHeight;
+}
+
 VideoPairMatchConfig VideoPairMatcher::configFromPrefs(const Prefs& prefs)
 {
     return {prefs.comparisonMode(), prefs.thumbnailsMode(),      prefs._thresholdPhash,
@@ -102,6 +112,7 @@ VideoPairMatchResult VideoPairMatcher::match(const Video& left, const Video& rig
         for (int hashIndex = 0; hashIndex < hashes; ++hashIndex) {
             VideoPairMatchResult rotated = scoreFingerprints(left, right, left.fingerprint(hashIndex),
                                                              right.fingerprint(hashIndex, rotation), config, true);
+            rotated.rotation = rotation;
             if (rotated.phashSimilarity > bestResult.phashSimilarity)
                 bestResult = rotated;
             if (rotated.matches)

--- a/QtProject/app/comparison/internal/videopairmatcher.h
+++ b/QtProject/app/comparison/internal/videopairmatcher.h
@@ -35,7 +35,14 @@ struct VideoPairMatchResult {
     bool matches = false;
     int phashSimilarity = 0;
     double ssimSimilarity = 0.0;
+    // Rotation applied to the right video's fingerprint for this result. Auto trash needs it to compare resolutions:
+    // a 90/270 copy has its width and height swapped, so the raw dimensions never agree even though it is the same video.
+    FingerprintRotation rotation = FingerprintRotation::none;
 };
+
+// Whether two videos have the same resolution once the rotation that matched them is taken into account.
+bool sameResolutionUnderRotation(short leftWidth, short leftHeight, short rightWidth, short rightHeight,
+                                 FingerprintRotation rotation);
 
 struct MatchedVideoPair {
     int left = 0;

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -197,7 +197,7 @@ Db::~Db()
 
 namespace
 {
-const QString metadataDateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+const QString metadataDateTimeFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss.zzz");
 } // namespace
 
 bool Db::readMetadata(Video& video) const
@@ -217,15 +217,15 @@ bool Db::readMetadata(Video& video) const
     }
 
     while (query.next()) {
-        // TEMPORARY, remove a few releases after v1.15.0: caches written by v1.14.0 and earlier have no timestamps,
-        // ALTER TABLE left the modified/birth_time columns NULL on every existing row. Since hits are never rewritten,
-        // those rows would stay dateless forever and auto delete by dates would compare invalid QDateTimes, which Qt
-        // orders before any valid one, making the legacy copy always "earlier". Reporting a miss instead makes the next
-        // WITH_CACHE scan re-read the header and rewrite the row with dates (captures are still read from cache).
-        // Failure rows carry no dates by design and must keep skipping.
-        const bool legacyRowWithoutDates = query.value(QStringLiteral("modified")).toString().isEmpty()
-                                           && query.value(QStringLiteral("failure")).toString().isEmpty();
-        if (legacyRowWithoutDates)
+        // TEMPORARY, remove a few releases after v1.15.0: caches written by v1.14.0 and earlier have no timestamps
+        // (ALTER TABLE left modified/birth_time NULL). Hits are never rewritten, so those rows would stay dateless
+        // forever and auto delete by dates would compare invalid QDateTimes, which Qt orders before any valid one,
+        // making the legacy copy always "earlier". A miss makes the next WITH_CACHE scan re-read the header and
+        // rewrite the row with dates (captures are still read from cache). Failure rows carry no dates by design
+        // and must keep skipping.
+        const QDateTime modified =
+            QDateTime::fromString(query.value(QStringLiteral("modified")).toString(), metadataDateTimeFormat);
+        if (!modified.isValid() && query.value(QStringLiteral("failure")).toString().isEmpty())
             return false;
 
         video.size = query.value(QStringLiteral("size")).toLongLong();
@@ -248,8 +248,7 @@ bool Db::readMetadata(Video& video) const
         video.meta.additionalMetadata = map;
         video.meta.setRelevantValuesFromAdditionalMetadata();
         video.cachedFailure = query.value(QStringLiteral("failure")).toString();
-        video.modified =
-            QDateTime::fromString(query.value(QStringLiteral("modified")).toString(), metadataDateTimeFormat);
+        video.modified = modified;
         video._fileCreateDate =
             QDateTime::fromString(query.value(QStringLiteral("birth_time")).toString(), metadataDateTimeFormat);
         return true;

--- a/QtProject/app/db.cpp
+++ b/QtProject/app/db.cpp
@@ -217,6 +217,17 @@ bool Db::readMetadata(Video& video) const
     }
 
     while (query.next()) {
+        // TEMPORARY, remove a few releases after v1.15.0: caches written by v1.14.0 and earlier have no timestamps,
+        // ALTER TABLE left the modified/birth_time columns NULL on every existing row. Since hits are never rewritten,
+        // those rows would stay dateless forever and auto delete by dates would compare invalid QDateTimes, which Qt
+        // orders before any valid one, making the legacy copy always "earlier". Reporting a miss instead makes the next
+        // WITH_CACHE scan re-read the header and rewrite the row with dates (captures are still read from cache).
+        // Failure rows carry no dates by design and must keep skipping.
+        const bool legacyRowWithoutDates = query.value(QStringLiteral("modified")).toString().isEmpty()
+                                           && query.value(QStringLiteral("failure")).toString().isEmpty();
+        if (legacyRowWithoutDates)
+            return false;
+
         video.size = query.value(QStringLiteral("size")).toLongLong();
         video.duration = query.value(QStringLiteral("duration")).toLongLong();
         video.bitrate = query.value(QStringLiteral("bitrate")).toInt();

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -25,6 +25,17 @@ int normalizedRightAngle(int angle)
     return 0;
 }
 
+// Cache stores modified/birth_time as yyyy-MM-dd HH:mm:ss, so drop sub-second
+// bits from the live QFileInfo values. Otherwise a cache hit (truncated) compared
+// to a fresh extract of a copy with the same mtime (milliseconds kept) is always
+// "earlier", and auto trash by dates systematically prefers the already-cached disk.
+QDateTime atWholeSeconds(QDateTime dt)
+{
+    if (dt.isValid())
+        dt = dt.addMSecs(-dt.time().msec());
+    return dt;
+}
+
 // Display Matrix is the modern representation and takes precedence over the legacy rotate tag.
 // Both describe the same presentation transform, so they must never be applied cumulatively.
 int presentationRotation(const ffmpeg::AVStream* stream)
@@ -301,9 +312,10 @@ const QString Video::getMetadata(const QString& filename)
 
     ffmpeg::avformat_close_input(&fmt_ctx);
 
-    modified = videoFile.lastModified(); // get it at the end so as not to have a date when other infos are empty
+    // get dates at the end so as not to have a date when other infos are empty
+    modified = atWholeSeconds(videoFile.lastModified());
     if (videoFile.birthTime().isValid())
-        _fileCreateDate = videoFile.birthTime();
+        _fileCreateDate = atWholeSeconds(videoFile.birthTime());
 
     return ""; // success !
 }

--- a/QtProject/app/video.cpp
+++ b/QtProject/app/video.cpp
@@ -25,17 +25,6 @@ int normalizedRightAngle(int angle)
     return 0;
 }
 
-// Cache stores modified/birth_time as yyyy-MM-dd HH:mm:ss, so drop sub-second
-// bits from the live QFileInfo values. Otherwise a cache hit (truncated) compared
-// to a fresh extract of a copy with the same mtime (milliseconds kept) is always
-// "earlier", and auto trash by dates systematically prefers the already-cached disk.
-QDateTime atWholeSeconds(QDateTime dt)
-{
-    if (dt.isValid())
-        dt = dt.addMSecs(-dt.time().msec());
-    return dt;
-}
-
 // Display Matrix is the modern representation and takes precedence over the legacy rotate tag.
 // Both describe the same presentation transform, so they must never be applied cumulatively.
 int presentationRotation(const ffmpeg::AVStream* stream)
@@ -312,10 +301,9 @@ const QString Video::getMetadata(const QString& filename)
 
     ffmpeg::avformat_close_input(&fmt_ctx);
 
-    // get dates at the end so as not to have a date when other infos are empty
-    modified = atWholeSeconds(videoFile.lastModified());
+    modified = videoFile.lastModified(); // get it at the end so as not to have a date when other infos are empty
     if (videoFile.birthTime().isValid())
-        _fileCreateDate = atWholeSeconds(videoFile.birthTime());
+        _fileCreateDate = videoFile.birthTime();
 
     return ""; // success !
 }

--- a/QtProject/app/videodiscovery.cpp
+++ b/QtProject/app/videodiscovery.cpp
@@ -92,9 +92,10 @@ VideoDiscoveryResult discoverVideos(const QStringList& directories, const QStrin
 
         // One pass per folder. Subdirectories is omitted so a .photoslibrary can be replaced by originals/ instead
         // of walking resources/. Symlinked folders are left alone, which also prevents recursion cycles.
-        // Hidden entries are included, matching master’s default QDir::AllEntries walk, so hidden videos are found and
-        // Stop is observable on hidden non-video entries too.
-        QDirIterator iter(folder, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot | QDir::Hidden);
+        // Hidden entries are skipped, as QDir's default filter and the recursive QDirIterator it replaced always did.
+        // That keeps the app out of trash folders (~/.Trash, ~/.local/share/Trash), where it would rediscover the
+        // duplicates it trashed itself and pit them against the copies it kept.
+        QDirIterator iter(folder, QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
         while (iter.hasNext()) {
             const QFileInfo entry = iter.nextFileInfo();
             const bool isDirectory = entry.isDir();

--- a/QtProject/tests/CMakeLists.txt
+++ b/QtProject/tests/CMakeLists.txt
@@ -100,11 +100,11 @@ add_qt_test(test_mainwindow
     SOURCES test_mainwindow/tst_mainwindow.cpp
 )
 
-# failed-video negative cache uses generated temporary files and no fixture corpus
+# failed-video cache policy; copies a tracked sample when extraction has to succeed
 add_qt_test(test_failed_video_cache
     SOURCES test_failed_video_cache/tst_failed_video_cache.cpp
 )
-set_tests_properties(test_failed_video_cache PROPERTIES RUN_SERIAL TRUE)
+set_tests_properties(test_failed_video_cache PROPERTIES RUN_SERIAL TRUE LABELS "repo-fixtures")
 
 # checked-in fixture cleanup flow
 add_qt_test(test_repo_auto_delete

--- a/QtProject/tests/repo/auto_delete/tst_auto_delete.cpp
+++ b/QtProject/tests/repo/auto_delete/tst_auto_delete.cpp
@@ -29,6 +29,7 @@ class TestAutoDelete : public QObject
     void test_matchingFeaturePairs_data();
     void test_matchingFeaturePairs();
     void test_keepBiggestMovesLetterboxedCopy();
+    void test_keepBiggestMovesRotatedCopyWithResolutionCheck();
 
   private:
     QString samplesDirPath() const;
@@ -235,6 +236,67 @@ void TestAutoDelete::test_keepBiggestMovesLetterboxedCopy()
     QVERIFY2(QFileInfo::exists(trashDir.filePath(originalName)),
              qPrintable(QStringLiteral("Expected video in trash: %1").arg(originalName)));
 
+    w.close();
+    QCoreApplication::processEvents();
+}
+
+// a-rot90.mp4 is a-original.mp4 physically rotated: 160x40 against 40x160. With rotation detection on they match,
+// and the resolution check must compare the rotated copy on its swapped dimensions instead of rejecting the pair.
+void TestAutoDelete::test_keepBiggestMovesRotatedCopyWithResolutionCheck()
+{
+    const QString originalName = QStringLiteral("a-original.mp4");
+    const QString rotatedName = QStringLiteral("a-rot90.mp4");
+    const QString originalSource = matchingFixturePath(originalName);
+    const QString rotatedSource = matchingFixturePath(rotatedName);
+    QVERIFY2(QFileInfo::exists(originalSource), qPrintable(QStringLiteral("Video not found: %1").arg(originalSource)));
+    QVERIFY2(QFileInfo::exists(rotatedSource), qPrintable(QStringLiteral("Video not found: %1").arg(rotatedSource)));
+
+    QTemporaryDir testVideosDir;
+    QVERIFY2(testVideosDir.isValid(), "Could not create temporary video folder");
+    QTemporaryDir trashDir;
+    QVERIFY2(trashDir.isValid(), "Could not create temporary trash folder");
+
+    const QString originalPath = testVideosDir.filePath(originalName);
+    const QString rotatedPath = testVideosDir.filePath(rotatedName);
+    QVERIFY(QFile::copy(originalSource, originalPath));
+    QVERIFY(QFile::copy(rotatedSource, rotatedPath));
+
+    // The fixtures differ by a few hundred bytes only; pad the rotated copy past the 100 KiB "still equal" margin.
+    QFile paddedCopy(rotatedPath);
+    QVERIFY(paddedCopy.open(QIODevice::Append));
+    QCOMPARE(paddedCopy.write(QByteArray(101 * 1024, '\0')), qint64(101 * 1024));
+    paddedCopy.close();
+
+    Prefs prefs;
+    Db::emptyAllDb(prefs);
+
+    MainWindow w;
+    w.show();
+    w._prefs.useCacheOption(Prefs::NO_CACHE);
+    w._prefs.delMode = Prefs::CUSTOM_TRASH;
+    w._prefs.customTrashFolder(QDir(trashDir.path()));
+    w.on_thresholdSlider_valueChanged(90);
+    w.ui->detectRotatedCopiesCheckbox->setChecked(true);
+    w._everyVideo = discoverVideos({testVideosDir.path()}, w._extensionList).videos;
+    w.processVideos();
+
+    QCOMPARE(w._everyVideo.count(), 2);
+    QCOMPARE(w._videoList.count(), 2);
+    Comparison comp(w._videoList, w._prefs, w.geometry());
+    QCOMPARE(comp.reportMatchingVideos(), 1);
+    comp.ui->disableDeleteConfirmationCheckbox->setChecked(true);
+    QVERIFY(!comp.ui->autoOnlySizeDontCheckResFpsCheckbox->isChecked());
+    QVERIFY(comp.ui->radioButton_onlySizeDiffers_keepBiggest->isChecked());
+    acceptMessageBoxesDuring(2, [&comp] { comp.on_autoDelOnlySizeDiffersButton_clicked(); });
+
+    QVERIFY2(!QFileInfo::exists(originalPath),
+             qPrintable(QStringLiteral("Expected moved video: %1").arg(originalPath)));
+    QVERIFY2(QFileInfo::exists(rotatedPath),
+             qPrintable(QStringLiteral("Expected retained video: %1").arg(rotatedPath)));
+    QVERIFY2(QFileInfo::exists(trashDir.filePath(originalName)),
+             qPrintable(QStringLiteral("Expected video in trash: %1").arg(originalName)));
+
+    w.ui->detectRotatedCopiesCheckbox->setChecked(false);
     w.close();
     QCoreApplication::processEvents();
 }

--- a/QtProject/tests/test_comparison/tst_test_comparison.cpp
+++ b/QtProject/tests/test_comparison/tst_test_comparison.cpp
@@ -37,6 +37,7 @@ class test_comparison : public QObject
     void cleanupTestCase();
 
     void test_videoToDelete_OnlyTimeDiffs();
+    void test_videoToDelete_RotatedCopyComparesSwappedResolution();
 #ifdef Q_OS_MACOS
     void test_applePhotosNameLookupIsSynchronousAndSessionOnly();
     void test_applePhotosNameLookupReportsRefusedAccess();
@@ -99,41 +100,78 @@ void test_comparison::test_videoToDelete_OnlyTimeDiffs()
     Comparison::AutoDeleteUserSettings userSet(false); // trash later video as is default
 
     //check default case, all exact same so should not be covered in this auto mode
-    const VideoMetadata* vidToDeleteMetaPtr = autoDelConf.videoToDelete(&meta1, &meta2, userSet);
+    const VideoMetadata* vidToDeleteMetaPtr =
+        autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none);
     QVERIFY2(vidToDeleteMetaPtr == nullptr, "Vids date metadata same but auto date comparison said they're different");
 
     meta1._fileCreateDate = earlierDate;
     meta2._fileCreateDate = laterDate;
-    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet) == &meta2,
+    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none) == &meta2,
              "Should have delete later creation date video but selected ealier");
 
     meta1._fileCreateDate = laterDate;
     meta2._fileCreateDate = earlierDate;
-    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet) == &meta1,
+    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none) == &meta1,
              "Should have delete later creation date video but selected ealier");
 
     meta1._fileCreateDate = refDate;
     meta2._fileCreateDate = refDate;
     meta1.modified = earlierDate;
     meta2.modified = laterDate;
-    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet) == &meta2,
+    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none) == &meta2,
              "Should have delete later modified date video but selected ealier");
 
     meta1._fileCreateDate = refDate;
     meta2._fileCreateDate = refDate;
     meta1.modified = laterDate;
     meta2.modified = earlierDate;
-    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet) == &meta1,
+    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none) == &meta1,
              "Should have delete later modified date video but selected ealier");
 
     meta1._fileCreateDate = earlierDate;
     meta2._fileCreateDate = laterDate;
     meta1.modified = laterDate;
     meta2.modified = earlierDate;
-    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet) == &meta2,
+    QVERIFY2(autoDelConf.videoToDelete(&meta1, &meta2, userSet, FingerprintRotation::none) == &meta2,
              "Later creation date should be deleted but instead later modified date or else was");
 
     // TODO could add more interesting tests with small differences, and check more specifically the outcomes
+}
+
+// A 90/270 rotated copy has swapped width and height, so it is the same resolution only when the rotation the pair
+// matched under is taken into account. Without it the pair must still be rejected, as must a real resolution change.
+void test_comparison::test_videoToDelete_RotatedCopyComparesSwappedResolution()
+{
+    VideoMetadata meta1, meta2;
+    meta1.size = meta2.size = 36 * 10 * 1024;
+    meta1.duration = meta2.duration = 36 * 1000;
+    meta1.framerate = meta2.framerate = 30;
+    meta1.codec = meta2.codec = "hevc";
+    meta1.bitrate = meta2.bitrate = 10 * 1024;
+    meta1.audio = meta2.audio = "aac";
+    meta1._fileCreateDate = QDateTime(QDate(1999, 1, 1), QTime(1, 0, 0));
+    meta2._fileCreateDate = QDateTime(QDate(2001, 1, 1), QTime(1, 0, 0));
+    meta1.width = 1920;
+    meta1.height = 1080;
+    meta2.width = 1080;
+    meta2.height = 1920;
+
+    Comparison::AutoDeleteConfig autoDelConf(Comparison::AUTO_DELETE_ONLY_TIMES_DIFF);
+    Comparison::AutoDeleteUserSettings trashLater(false);
+
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::none) == nullptr);
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::rotated180) == nullptr);
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::clockwise90) == &meta2);
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::counterClockwise90) == &meta2);
+
+    meta2.width = 1080;
+    meta2.height = 1440;
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::clockwise90) == nullptr);
+
+    meta2.width = 1920;
+    meta2.height = 1080;
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::rotated180) == &meta2);
+    QVERIFY(autoDelConf.videoToDelete(&meta1, &meta2, trashLater, FingerprintRotation::clockwise90) == nullptr);
 }
 
 #ifdef Q_OS_MACOS
@@ -273,6 +311,7 @@ void test_comparison::test_videoPairMatcherUsesConfigSnapshot()
     const auto result = VideoPairMatcher::match(left, right, config);
     QVERIFY(result.matches);
     QCOMPARE(result.phashSimilarity, 63);
+    QCOMPARE(result.rotation, FingerprintRotation::none);
 }
 
 void test_comparison::test_ssimUsesEachBlockForMeans()
@@ -319,6 +358,8 @@ void test_comparison::test_rotatedMatcherRequiresSsimSafeguard()
     right.fingerprint(0, FingerprintRotation::clockwise90).ssimPixels = left.fingerprint(0).ssimPixels;
     const VideoPairMatchResult result = VideoPairMatcher::match(left, right, config);
     QVERIFY(result.matches);
+    // Auto trash compares resolutions under this rotation, so the matcher has to report which one matched.
+    QCOMPARE(result.rotation, FingerprintRotation::clockwise90);
 }
 
 void test_comparison::test_rotatedMatcherAppliesDurationModifierToSsimThreshold()

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -109,7 +109,7 @@ class TestFailedVideoCache : public QObject
     void cleanup();
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
-    void test_liveDatesTruncatedToCachedSecondPrecision();
+    void test_cachedDatesKeepMilliseconds();
     void test_legacyRowWithoutDatesIsRefreshed();
     void test_cacheOnlyDoesNotPersistFailures();
     void test_databaseClearingAndRemoval();
@@ -224,8 +224,8 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(Db::emptyAllDb(prefs));
 
-    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0));
-    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0));
+    const QDateTime modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0, 347));
+    const QDateTime birthTime = QDateTime(QDate(2020, 1, 2), QTime(8, 0, 0, 12));
     {
         Db cache(cachePath);
         Video metadata(prefs, videoPath);
@@ -247,10 +247,9 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     QCOMPARE(loaded._fileCreateDate, birthTime);
 }
 
-// Copies with preserved mtimes share the same second; the cache stores that second only. Live QFileInfo
-// keeps milliseconds, so without truncating at extract time a cache hit is always earlier than a fresh
-// extract of the duplicate and auto trash by dates always prefers the already-cached disk.
-void TestFailedVideoCache::test_liveDatesTruncatedToCachedSecondPrecision()
+// Live QFileInfo keeps milliseconds; the cache must too, otherwise a cache hit compared to a fresh extract of a copy
+// with the same mtime is always earlier and auto trash by dates always prefers the already-cached disk.
+void TestFailedVideoCache::test_cachedDatesKeepMilliseconds()
 {
     QTemporaryDir temporary;
     QVERIFY(temporary.isValid());
@@ -270,10 +269,13 @@ void TestFailedVideoCache::test_liveDatesTruncatedToCachedSecondPrecision()
     QVERIFY(Db::emptyAllDb(prefs));
     Video extracted(prefs, videoPath);
     QCOMPARE(extracted.process().errorMsg, QString());
-    QCOMPARE(extracted.modified.time().msec(), 0);
-    QCOMPARE(extracted.modified, QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0)));
-    QVERIFY(extracted.modified != QFileInfo(videoPath).lastModified());
-    QCOMPARE(extracted.modified.toSecsSinceEpoch(), QFileInfo(videoPath).lastModified().toSecsSinceEpoch());
+    QCOMPARE(extracted.modified.time().msec(), 347);
+    QCOMPARE(extracted.modified, QFileInfo(videoPath).lastModified());
+
+    Video loaded(prefs, videoPath);
+    QVERIFY(Db(cachePath).readMetadata(loaded));
+    QCOMPARE(loaded.modified.time().msec(), 347);
+    QCOMPARE(loaded.modified, extracted.modified);
 }
 
 // Pre-v1.15.0 caches have NULL modified/birth_time on every row. Such a row must read as a miss so one WITH_CACHE scan

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -109,7 +109,6 @@ class TestFailedVideoCache : public QObject
     void cleanup();
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
-    void test_cachedDatesKeepMilliseconds();
     void test_legacyRowWithoutDatesIsRefreshed();
     void test_cacheOnlyDoesNotPersistFailures();
     void test_databaseClearingAndRemoval();
@@ -247,14 +246,14 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     QCOMPARE(loaded._fileCreateDate, birthTime);
 }
 
-// Live QFileInfo keeps milliseconds; the cache must too, otherwise a cache hit compared to a fresh extract of a copy
-// with the same mtime is always earlier and auto trash by dates always prefers the already-cached disk.
-void TestFailedVideoCache::test_cachedDatesKeepMilliseconds()
+// Remove with the TEMPORARY dateless-row miss in Db::readMetadata a few releases after v1.15.0.
+// A real video is required so process() can succeed and rewrite the row (junk bytes never get that far).
+void TestFailedVideoCache::test_legacyRowWithoutDatesIsRefreshed()
 {
     QTemporaryDir temporary;
     QVERIFY(temporary.isValid());
     const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
-    const QString videoPath = temporary.filePath(QStringLiteral("dated.mp4"));
+    const QString videoPath = temporary.filePath(QStringLiteral("legacy.mp4"));
     QVERIFY(QFile::copy(sampleVideoPath(QStringLiteral("Nice_383p_500kbps.mp4")), videoPath));
 
     const QDateTime live = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0, 347));
@@ -264,29 +263,6 @@ void TestFailedVideoCache::test_cachedDatesKeepMilliseconds()
         QVERIFY(file.setFileTime(live, QFileDevice::FileModificationTime));
     }
     QCOMPARE(QFileInfo(videoPath).lastModified().time().msec(), 347);
-
-    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
-    QVERIFY(Db::emptyAllDb(prefs));
-    Video extracted(prefs, videoPath);
-    QCOMPARE(extracted.process().errorMsg, QString());
-    QCOMPARE(extracted.modified.time().msec(), 347);
-    QCOMPARE(extracted.modified, QFileInfo(videoPath).lastModified());
-
-    Video loaded(prefs, videoPath);
-    QVERIFY(Db(cachePath).readMetadata(loaded));
-    QCOMPARE(loaded.modified.time().msec(), 347);
-    QCOMPARE(loaded.modified, extracted.modified);
-}
-
-// Pre-v1.15.0 caches have NULL modified/birth_time on every row. Such a row must read as a miss so one WITH_CACHE scan
-// rewrites it with dates, otherwise auto delete by dates would compare invalid QDateTimes. Failure rows keep skipping.
-void TestFailedVideoCache::test_legacyRowWithoutDatesIsRefreshed()
-{
-    QTemporaryDir temporary;
-    QVERIFY(temporary.isValid());
-    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
-    const QString videoPath = temporary.filePath(QStringLiteral("legacy.mp4"));
-    QVERIFY(QFile::copy(sampleVideoPath(QStringLiteral("Nice_383p_500kbps.mp4")), videoPath));
 
     const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
     QVERIFY(Db::emptyAllDb(prefs));
@@ -313,7 +289,8 @@ void TestFailedVideoCache::test_legacyRowWithoutDatesIsRefreshed()
     QVERIFY(Db(cachePath).readMetadata(refreshed));
     QVERIFY(refreshed.codec != QStringLiteral("legacy"));
     QVERIFY(refreshed.duration > 1000);
-    QCOMPARE(refreshed.modified.toSecsSinceEpoch(), QFileInfo(videoPath).lastModified().toSecsSinceEpoch());
+    QCOMPARE(refreshed.modified.time().msec(), 347);
+    QCOMPARE(refreshed.modified, QFileInfo(videoPath).lastModified());
     QCOMPARE(processError(videoPath, cachePath, Prefs::CACHE_ONLY, cutEnds), QString());
 
     const QString failedPath = temporary.filePath(QStringLiteral("failed.mp4"));

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -56,7 +56,22 @@ void writePlausibleMetadata(const Db& cache, const Prefs& prefs, const QString& 
     metadata.width = width;
     metadata.height = height;
     metadata.cachedFailure = failure;
+    // Successful rows always carry the modified date, a row without one is a pre-v1.15.0 legacy row.
+    metadata.modified = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0));
     cache.writeMetadata(metadata);
+}
+
+// Locates the tracked samples so the test can copy a real video into its temporary folder.
+QString sampleVideoPath(const QString& fileName)
+{
+    QString projectRoot = QDir::currentPath();
+    while (!QFileInfo::exists(projectRoot + QStringLiteral("/samples/videos")) && projectRoot != QStringLiteral("/")) {
+        QDir dir(projectRoot);
+        if (!dir.cdUp())
+            break;
+        projectRoot = dir.absolutePath();
+    }
+    return projectRoot + QStringLiteral("/samples/videos/") + fileName;
 }
 
 bool hasMetadata(const QString& cachePath, const QString& path)
@@ -93,6 +108,7 @@ class TestFailedVideoCache : public QObject
     void cleanup();
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
+    void test_legacyRowWithoutDatesIsRefreshed();
     void test_cacheOnlyDoesNotPersistFailures();
     void test_databaseClearingAndRemoval();
     void test_failureSkipsUntilCacheBypassedOrEmptied();
@@ -227,6 +243,51 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     QVERIFY(Db(cachePath).readMetadata(loaded));
     QCOMPARE(loaded.modified, modified);
     QCOMPARE(loaded._fileCreateDate, birthTime);
+}
+
+// Pre-v1.15.0 caches have NULL modified/birth_time on every row. Such a row must read as a miss so one WITH_CACHE scan
+// rewrites it with dates, otherwise auto delete by dates would compare invalid QDateTimes. Failure rows keep skipping.
+void TestFailedVideoCache::test_legacyRowWithoutDatesIsRefreshed()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("legacy.mp4"));
+    QVERIFY(QFile::copy(sampleVideoPath(QStringLiteral("Nice_383p_500kbps.mp4")), videoPath));
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+    {
+        Db cache(cachePath);
+        Video legacy(prefs, videoPath);
+        legacy.size = QFileInfo(videoPath).size();
+        legacy.duration = 1000;
+        legacy.bitrate = 100;
+        legacy.framerate = 25;
+        legacy.codec = QStringLiteral("legacy");
+        legacy.width = 16;
+        legacy.height = 16;
+        cache.writeMetadata(legacy); // invalid dates are stored empty, like the NULL an ALTER TABLE upgrade leaves
+    }
+    QVERIFY(!hasMetadata(cachePath, videoPath));
+
+    // Cache only has nothing usable until a WITH_CACHE scan has refreshed the row.
+    QVERIFY(processError(videoPath, cachePath, Prefs::CACHE_ONLY, cutEnds)
+                .contains(QStringLiteral("video was not fully cached")));
+
+    QCOMPARE(processError(videoPath, cachePath, Prefs::WITH_CACHE, cutEnds), QString());
+    Video refreshed(prefs, videoPath);
+    QVERIFY(Db(cachePath).readMetadata(refreshed));
+    QVERIFY(refreshed.codec != QStringLiteral("legacy"));
+    QVERIFY(refreshed.duration > 1000);
+    QCOMPARE(refreshed.modified.toSecsSinceEpoch(), QFileInfo(videoPath).lastModified().toSecsSinceEpoch());
+    QCOMPARE(processError(videoPath, cachePath, Prefs::CACHE_ONLY, cutEnds), QString());
+
+    const QString failedPath = temporary.filePath(QStringLiteral("failed.mp4"));
+    QVERIFY(writeInvalidVideo(failedPath, QByteArrayLiteral("not a video")));
+    Db(cachePath).writeFailure(failedPath, QStringLiteral("boom"));
+    QVERIFY(hasMetadata(cachePath, failedPath));
+    QCOMPARE(processError(failedPath, cachePath, Prefs::WITH_CACHE, cutEnds), skippedMessage(QStringLiteral("boom")));
 }
 
 void TestFailedVideoCache::test_cacheOnlyDoesNotPersistFailures()

--- a/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
+++ b/QtProject/tests/test_failed_video_cache/tst_failed_video_cache.cpp
@@ -1,5 +1,6 @@
 #include <QBuffer>
 #include <QFile>
+#include <QFileDevice>
 #include <QFileInfo>
 #include <QImage>
 #include <QTemporaryDir>
@@ -108,6 +109,7 @@ class TestFailedVideoCache : public QObject
     void cleanup();
     void test_processingCachePolicy();
     void test_metadataDatesAreCached();
+    void test_liveDatesTruncatedToCachedSecondPrecision();
     void test_legacyRowWithoutDatesIsRefreshed();
     void test_cacheOnlyDoesNotPersistFailures();
     void test_databaseClearingAndRemoval();
@@ -243,6 +245,35 @@ void TestFailedVideoCache::test_metadataDatesAreCached()
     QVERIFY(Db(cachePath).readMetadata(loaded));
     QCOMPARE(loaded.modified, modified);
     QCOMPARE(loaded._fileCreateDate, birthTime);
+}
+
+// Copies with preserved mtimes share the same second; the cache stores that second only. Live QFileInfo
+// keeps milliseconds, so without truncating at extract time a cache hit is always earlier than a fresh
+// extract of the duplicate and auto trash by dates always prefers the already-cached disk.
+void TestFailedVideoCache::test_liveDatesTruncatedToCachedSecondPrecision()
+{
+    QTemporaryDir temporary;
+    QVERIFY(temporary.isValid());
+    const QString cachePath = temporary.filePath(QStringLiteral("cache.sqlite"));
+    const QString videoPath = temporary.filePath(QStringLiteral("dated.mp4"));
+    QVERIFY(QFile::copy(sampleVideoPath(QStringLiteral("Nice_383p_500kbps.mp4")), videoPath));
+
+    const QDateTime live = QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0, 347));
+    {
+        QFile file(videoPath);
+        QVERIFY(file.open(QIODevice::ReadWrite));
+        QVERIFY(file.setFileTime(live, QFileDevice::FileModificationTime));
+    }
+    QCOMPARE(QFileInfo(videoPath).lastModified().time().msec(), 347);
+
+    const Prefs prefs = cachePrefs(cachePath, Prefs::WITH_CACHE, cutEnds);
+    QVERIFY(Db::emptyAllDb(prefs));
+    Video extracted(prefs, videoPath);
+    QCOMPARE(extracted.process().errorMsg, QString());
+    QCOMPARE(extracted.modified.time().msec(), 0);
+    QCOMPARE(extracted.modified, QDateTime(QDate(2024, 3, 15), QTime(10, 30, 0)));
+    QVERIFY(extracted.modified != QFileInfo(videoPath).lastModified());
+    QCOMPARE(extracted.modified.toSecsSinceEpoch(), QFileInfo(videoPath).lastModified().toSecsSinceEpoch());
 }
 
 // Pre-v1.15.0 caches have NULL modified/birth_time on every row. Such a row must read as a miss so one WITH_CACHE scan

--- a/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
+++ b/QtProject/tests/test_mainwindow/tst_mainwindow.cpp
@@ -25,7 +25,7 @@ class TestMainWindow : public QObject
     void test_discoveryCanBeCancelled();
     void test_discoveryCanBeCancelledWhileSkippingNonVideos();
     void test_videoExtensionsMatchRegardlessOfCase();
-    void test_hiddenEntriesAreDiscovered();
+    void test_hiddenEntriesAreSkipped();
     void test_loadVideoExtensionFilters();
     void test_emptyFolderScanLeavesNoSearchingMessage();
 
@@ -137,16 +137,17 @@ void TestMainWindow::test_videoExtensionsMatchRegardlessOfCase()
     QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({shouting, mixed}));
 }
 
-void TestMainWindow::test_hiddenEntriesAreDiscovered()
+// Hidden files and folders are left alone, as the recursive QDirIterator did: a scan of a home folder must not walk
+// into the trash and rediscover what the app itself moved there.
+void TestMainWindow::test_hiddenEntriesAreSkipped()
 {
-    const QString inHiddenDir = createFile(QStringLiteral(".private/cache/video.mp4"));
-    const QString hiddenFile = createFile(QStringLiteral("Movies/.hidden.mov"));
+    QVERIFY(!createFile(QStringLiteral(".private/cache/video.mp4")).isEmpty());
+    QVERIFY(!createFile(QStringLiteral(".Trash/trashed.mp4")).isEmpty());
+    QVERIFY(!createFile(QStringLiteral("Movies/.hidden.mov")).isEmpty());
     const QString normal = createFile(QStringLiteral("Movies/normal.mp4"));
-    QVERIFY(!inHiddenDir.isEmpty());
-    QVERIFY(!hiddenFile.isEmpty());
     QVERIFY(!normal.isEmpty());
 
-    QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({inHiddenDir, hiddenFile, normal}));
+    QCOMPARE(discoveredVideosIn(_scanRoot->path()), QSet<QString>({normal}));
 }
 
 void TestMainWindow::test_loadVideoExtensionFilters()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Four small pre-release fixes for things found while reviewing everything landed since v1.14.0, plus an AGENTS.md cleanup so fixture lanes are a rule instead of a per-target inventory.

## 1. Legacy cache rows without dates read as cache misses

`#214` started storing `modified`/`birth_time` on the metadata row and stopped re-reading them from disk on cache hits. Existing v1.14.0 caches get those columns via `ALTER TABLE ... ADD COLUMN`, which leaves them NULL on every row, and since hits are never rewritten those rows would stay dateless forever.

`AutoDeleteConfig::videoToDelete` compares `_fileCreateDate` / `modified` directly, and Qt orders an invalid `QDateTime` before any valid one. `Db::readMetadata` now returns `false` for a row whose `modified` does not parse as a valid timestamp, unless it is a failure row. The next `WITH_CACHE` scan re-reads the header and rewrites the row with dates (captures stay in the `capture` table). Marked `TEMPORARY`, remove a few releases after v1.15.0.

## 2. Discovery skips hidden files and folders again

`#211` added `QDir::Hidden` with a comment claiming it matched the previous default walk. It did not. The flag is dropped so home-folder scans do not walk trash.

## 3. Auto trash accepts rotated matches on their swapped resolution

Rotated copy detection matched 90/270 copies but auto trash still compared raw `width`/`height`. The matcher reports the fingerprint rotation (applied after presentation is already baked into frames and stored size). Auto trash compares resolutions under that rotation.

## 4. Cache file timestamps at millisecond precision

Live `QFileInfo` keeps milliseconds. The cache stores `modified`/`birth_time` as `yyyy-MM-dd HH:mm:ss.zzz`.

## 5. AGENTS.md fixture lanes

The guide listed individual test targets and said `test_failed_video_cache` uses only generated temps. That sentence was treated as a contract. It now states the lane: self-contained tests may use tracked `samples/videos` (prefer a real video when extraction must succeed); only `test_external_*` may use `~/Dev`. The millisecond-date check is folded into the one Nice copy in `test_legacyRowWithoutDatesIsRefreshed`. That target is labeled `repo-fixtures`.

## Tests

Self-contained CTest baseline passes on the Linux build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08c13-c6b1-740f-ac00-b050867eb403?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08c13-c6b1-740f-ac00-b050867eb403&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

